### PR TITLE
RPS-59 feat: support options pattern and direct POCO SDK configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,12 @@ var options = new PublishingPlatformClientOptions
 };
 ```
 
-## Create a client (no host)
+## Choose a configuration style
+
+- Use the Options pattern in hosted apps (ASP.NET Core, worker services) when configuration comes from `appsettings`, environment variables, or secrets providers and you want startup-time validation.
+- Use direct POCO/builder configuration in non-hosted apps, scripts, tests, or quick integrations where you construct options in code.
+
+## Create a client (no host, direct POCO)
 
 ```csharp
 using PublishingPlatform.SDK.Clients;
@@ -74,7 +79,19 @@ var client = PublishingPlatformClientBuilder.Create(new PublishingPlatformClient
 }).Build();
 ```
 
-## ASP.NET Core registration
+## ASP.NET Core registration (Options pattern)
+
+Option 1: bind and validate via `IOptions<PublishingPlatformClientOptions>`.
+
+```csharp
+using PublishingPlatform.SDK.Extensions;
+using PublishingPlatform.SDK.Options;
+
+builder.Services.Configure<PublishingPlatformClientOptions>(builder.Configuration.GetSection("PublishingPlatform"));
+builder.Services.AddPublishingPlatformClient();
+```
+
+Option 2: keep using direct configure callback.
 
 ```csharp
 using PublishingPlatform.SDK.Extensions;

--- a/src/PublishingPlatform.SDK/Extensions/ServiceCollectionExtensions.cs
+++ b/src/PublishingPlatform.SDK/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using PublishingPlatform.SDK.Exceptions;
 using PublishingPlatform.SDK.Abstractions;
 using PublishingPlatform.SDK.Clients;
 using PublishingPlatform.SDK.Infrastructure.Errors;
@@ -8,30 +10,70 @@ using PublishingPlatform.SDK.Options;
 
 namespace PublishingPlatform.SDK.Extensions;
 
+/// <summary>
+/// Provides dependency injection registration helpers for the Publishing Platform SDK.
+/// </summary>
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Registers SDK services and resolves configuration from <see cref="IOptions{TOptions}"/>.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The same service collection instance.</returns>
+    public static IServiceCollection AddPublishingPlatformClient(
+        this IServiceCollection services)
+    {
+        services.AddOptions<PublishingPlatformClientOptions>()
+            .Validate(ValidateOptions)
+            .ValidateOnStart();
+
+        RegisterPublishingPlatformClient(services);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers SDK services using direct POCO configuration for non-hosted or manual setup scenarios.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">The configuration callback that populates <see cref="PublishingPlatformClientOptions"/>.</param>
+    /// <returns>The same service collection instance.</returns>
     public static IServiceCollection AddPublishingPlatformClient(
         this IServiceCollection services,
         Action<PublishingPlatformClientOptions> configure)
     {
-        ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configure);
 
-        var options = new PublishingPlatformClientOptions();
-        configure(options);
+        services.AddOptions<PublishingPlatformClientOptions>()
+            .Configure(configure)
+            .Validate(ValidateOptions)
+            .ValidateOnStart();
 
-        services.AddSingleton(options);
+        RegisterPublishingPlatformClient(services);
 
-        services.AddHttpClient(SdkHttpClientResolver.ClientName, client =>
+        return services;
+    }
+
+    private static void RegisterPublishingPlatformClient(IServiceCollection services)
+    {
+        services.AddSingleton(sp => sp.GetRequiredService<IOptions<PublishingPlatformClientOptions>>().Value);
+        services.AddHttpClient(SdkHttpClientResolver.ClientName, (sp, client) =>
         {
+            var options = sp.GetRequiredService<IOptions<PublishingPlatformClientOptions>>().Value;
             client.BaseAddress = new Uri(options.BaseUrl, UriKind.Absolute);
             client.Timeout = options.Timeout;
         });
 
-        services.AddSingleton<IPublishingPlatformResiliencePipeline>(_ =>
-            ResiliencePipelineFactory.Create(options.Resilience));
-        services.AddSingleton<IPublishingPlatformErrorMapper>(_ =>
-            options.ErrorMapper ?? new DefaultPublishingPlatformErrorMapper());
+        services.AddSingleton<IPublishingPlatformResiliencePipeline>(sp =>
+        {
+            var options = sp.GetRequiredService<IOptions<PublishingPlatformClientOptions>>().Value;
+            return ResiliencePipelineFactory.Create(options.Resilience);
+        });
+        services.AddSingleton<IPublishingPlatformErrorMapper>(sp =>
+        {
+            var options = sp.GetRequiredService<IOptions<PublishingPlatformClientOptions>>().Value;
+            return options.ErrorMapper ?? new DefaultPublishingPlatformErrorMapper();
+        });
         services.AddSingleton<ICorrelationIdProvider, GuidCorrelationIdProvider>();
         services.AddSingleton<ISharedHttpTransport>(sp =>
         {
@@ -52,7 +94,20 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IBookAssetsClient>(sp => new BookAssetsClient(sp.GetRequiredService<ISharedHttpTransport>()));
         services.AddSingleton<IWebhooksClient>(sp => new WebhooksClient(sp.GetRequiredService<ISharedHttpTransport>()));
         services.AddSingleton<IPublishingPlatformClient, PublishingPlatformClient>();
+    }
 
-        return services;
+    private static bool ValidateOptions(PublishingPlatformClientOptions options)
+    {
+        if (!Uri.TryCreate(options.BaseUrl, UriKind.Absolute, out _))
+        {
+            throw new PublishingPlatformConfigurationException("BaseUrl must be a valid absolute URL.");
+        }
+
+        if (options.Timeout <= TimeSpan.Zero)
+        {
+            throw new PublishingPlatformConfigurationException("Timeout must be greater than zero.");
+        }
+
+        return true;
     }
 }

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/HandlersAndDiCoverageTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/HandlersAndDiCoverageTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using PublishingPlatform.SDK.Abstractions;
 using PublishingPlatform.SDK.Extensions;
 using PublishingPlatform.SDK.Infrastructure.Auth;
@@ -102,9 +103,35 @@ public sealed class HandlersAndDiCoverageTests
 
         Action nullConfigure = () => ServiceCollectionExtensions.AddPublishingPlatformClient(services, null!);
         Action nullServices = () => ServiceCollectionExtensions.AddPublishingPlatformClient(null!, _ => { });
+        Action nullServicesForOptions = () => ServiceCollectionExtensions.AddPublishingPlatformClient(null!);
 
         nullConfigure.Should().Throw<ArgumentNullException>();
         nullServices.Should().Throw<ArgumentNullException>();
+        nullServicesForOptions.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void AddPublishingPlatformClient_ResolvesFromOptionsPatternConfiguration()
+    {
+        var services = new ServiceCollection();
+        services.Configure<PublishingPlatformClientOptions>(options =>
+        {
+            options.BaseUrl = "https://api.example.test";
+            options.ApiKey = "key";
+            options.Timeout = TimeSpan.FromSeconds(18);
+        });
+        services.AddPublishingPlatformClient();
+
+        using var provider = services.BuildServiceProvider();
+
+        var options = provider.GetRequiredService<IOptions<PublishingPlatformClientOptions>>().Value;
+        var clientOptions = provider.GetRequiredService<PublishingPlatformClientOptions>();
+        var client = provider.GetRequiredService<IPublishingPlatformClient>();
+
+        options.BaseUrl.Should().Be("https://api.example.test");
+        options.Timeout.Should().Be(TimeSpan.FromSeconds(18));
+        clientOptions.BaseUrl.Should().Be("https://api.example.test");
+        client.Should().NotBeNull();
     }
 
     [Fact]

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/ResilienceAndTransportTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/ResilienceAndTransportTests.cs
@@ -1,5 +1,6 @@
 using Bogus;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using PublishingPlatform.SDK.Abstractions;
 using PublishingPlatform.SDK.Exceptions;
 using PublishingPlatform.SDK.Extensions;
@@ -204,6 +205,24 @@ public sealed class ResilienceAndTransportTests
         var resolvedMapper = provider.GetRequiredService<IPublishingPlatformErrorMapper>();
 
         resolvedMapper.Should().BeSameAs(customMapper);
+    }
+
+    [Fact]
+    public void AddPublishingPlatformClient_ThrowsForInvalidOptions_WhenUsingOptionsPattern()
+    {
+        var services = new ServiceCollection();
+        services.Configure<PublishingPlatformClientOptions>(options =>
+        {
+            options.BaseUrl = "invalid-url";
+        });
+        services.AddPublishingPlatformClient();
+
+        using var provider = services.BuildServiceProvider(validateScopes: true);
+
+        Action act = () => _ = provider.GetRequiredService<IOptions<PublishingPlatformClientOptions>>().Value;
+
+        act.Should().Throw<PublishingPlatformConfigurationException>()
+            .WithMessage("*BaseUrl must be a valid absolute URL.*");
     }
 
     [Fact]


### PR DESCRIPTION
## What
This PR adds first-class `Microsoft.Extensions.Options` support for hosted SDK consumers while preserving the existing direct POCO configuration path for non-hosted scenarios.

## Why
Issue #59 requests dual configuration support:
- Hosted users should be able to provide `PublishingPlatformClientOptions` through `IOptions<T>` / `Configure<T>`.
- Non-hosted users should continue using direct options objects and the builder.

## Changes
- Added new DI overload:
  - `AddPublishingPlatformClient(this IServiceCollection services)`
  - Resolves `PublishingPlatformClientOptions` via `IOptions<PublishingPlatformClientOptions>`
- Kept existing overload unchanged:
  - `AddPublishingPlatformClient(Action<PublishingPlatformClientOptions> configure)`
- Kept builder path unchanged:
  - `PublishingPlatformClientBuilder.Create(PublishingPlatformClientOptions options)`
- Centralized DI registration logic to avoid divergence between configuration paths.
- Added SDK options validation in DI registration:
  - `BaseUrl` must be an absolute URL
  - `Timeout` must be greater than zero
  - validation wired with startup validation behavior
- Updated README with practical guidance:
  - when to use Options pattern
  - when to use direct POCO/builder
  - side-by-side usage examples

## Tests
Added/updated tests for:
- Options-pattern registration and service resolution
- Direct configure-callback path continuity
- Validation failures and error messages for invalid options

All tests pass:
- `Passed: 33, Failed: 0`
