### PR TITLE
RPS-58 feat!: add operation-aware retry policy with opt-in POST/PATCH retries

### DIFF
--- a/.codex/skills/rps-developer-skill/SKILL.md
+++ b/.codex/skills/rps-developer-skill/SKILL.md
@@ -22,6 +22,7 @@ Use this skill when implementing or refactoring production SDK code, public abst
 
 - Follow SonarCloud default C# rules as the baseline quality standard.
 - Authoritative rules reference: https://sonarcloud.io/organizations/pavsavov/rules?languages=cs
+- Explicitly enforce `roslyn:CA1822` ("Mark members as static") when members do not access instance state.
 - Target `.NET 10` or higher for all new implementation work unless explicitly overridden by the user.
 - Code must be clean and maintainable:
   - intention-revealing names

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ var options = new PublishingPlatformClientOptions
         {
             Enabled = true,
             MaxRetryAttempts = 3,
-            BaseDelay = TimeSpan.FromMilliseconds(200)
+            BaseDelay = TimeSpan.FromMilliseconds(200),
+            RetryNonIdempotentMethods = false
         },
         CircuitBreaker = new CircuitBreakerResilienceOptions
         {
@@ -55,6 +56,8 @@ var client = PublishingPlatformClientBuilder.Create(new PublishingPlatformClient
 ## Opt-in resilience configuration
 
 Resilience is disabled by default. Enable only the strategies you need.
+By default, retries are applied only to idempotent methods (`GET`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, `TRACE`).
+Retries for non-idempotent methods (`POST`, `PATCH`) are explicit and opt-in.
 
 ```csharp
 var client = PublishingPlatformClientBuilder.Create(new PublishingPlatformClientOptions
@@ -74,6 +77,34 @@ var client = PublishingPlatformClientBuilder.Create(new PublishingPlatformClient
         {
             Enabled = true,
             Timeout = TimeSpan.FromSeconds(5)
+        }
+    }
+}).Build();
+```
+
+## Retry behavior defaults
+
+| HTTP Method Category | Default Retry Behavior | Transient Statuses |
+| --- | --- | --- |
+| Idempotent (`GET`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, `TRACE`) | Retry enabled when retry strategy is enabled | `429`, `502`, `503`, `504` |
+| Non-idempotent (`POST`, `PATCH`) | Not retried by default | N/A |
+
+You can opt in to retries for non-idempotent methods:
+
+```csharp
+var client = PublishingPlatformClientBuilder.Create(new PublishingPlatformClientOptions
+{
+    BaseUrl = "https://api.books.example",
+    ApiKey = "your-api-key",
+    Resilience = new PublishingPlatformResilienceOptions
+    {
+        Enabled = true,
+        Retry = new RetryResilienceOptions
+        {
+            Enabled = true,
+            MaxRetryAttempts = 3,
+            BaseDelay = TimeSpan.FromMilliseconds(200),
+            RetryNonIdempotentMethods = true
         }
     }
 }).Build();

--- a/examples/BasicUsage/PublishingPlatformClientExample.csx
+++ b/examples/BasicUsage/PublishingPlatformClientExample.csx
@@ -14,7 +14,8 @@ var client = PublishingPlatformClientBuilder.Create(new PublishingPlatformClient
         {
             Enabled = true,
             MaxRetryAttempts = 3,
-            BaseDelay = TimeSpan.FromMilliseconds(200)
+            BaseDelay = TimeSpan.FromMilliseconds(200),
+            RetryNonIdempotentMethods = false
         }
     }
 }).Build();

--- a/examples/RetryPolicy/README.md
+++ b/examples/RetryPolicy/README.md
@@ -1,0 +1,10 @@
+# Retry Policy
+
+Use `RetryPolicyExample.csx` to configure retry behavior with explicit defaults:
+
+- `RetryNonIdempotentMethods = false`:
+  retries only idempotent requests (`GET`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, `TRACE`).
+- `RetryNonIdempotentMethods = true`:
+  allows retries for `POST` and `PATCH` using the SDK's safer transient set.
+
+This keeps non-idempotent retries explicit and opt-in.

--- a/examples/RetryPolicy/RetryPolicyExample.csx
+++ b/examples/RetryPolicy/RetryPolicyExample.csx
@@ -1,0 +1,41 @@
+#r "../../src/PublishingPlatform.SDK/bin/Debug/net10.0/PublishingPlatform.SDK.dll"
+
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Options;
+
+var clientWithIdempotentRetriesOnly = PublishingPlatformClientBuilder.Create(new PublishingPlatformClientOptions
+{
+    BaseUrl = "https://api.books.example",
+    ApiKey = "demo-key",
+    Resilience = new PublishingPlatformResilienceOptions
+    {
+        Enabled = true,
+        Retry = new RetryResilienceOptions
+        {
+            Enabled = true,
+            MaxRetryAttempts = 3,
+            BaseDelay = TimeSpan.FromMilliseconds(200),
+            RetryNonIdempotentMethods = false
+        }
+    }
+}).Build();
+
+var clientWithPostPatchRetries = PublishingPlatformClientBuilder.Create(new PublishingPlatformClientOptions
+{
+    BaseUrl = "https://api.books.example",
+    ApiKey = "demo-key",
+    Resilience = new PublishingPlatformResilienceOptions
+    {
+        Enabled = true,
+        Retry = new RetryResilienceOptions
+        {
+            Enabled = true,
+            MaxRetryAttempts = 3,
+            BaseDelay = TimeSpan.FromMilliseconds(200),
+            RetryNonIdempotentMethods = true
+        }
+    }
+}).Build();
+
+Console.WriteLine(clientWithIdempotentRetriesOnly.GetType().Name);
+Console.WriteLine(clientWithPostPatchRetries.GetType().Name);

--- a/src/PublishingPlatform.SDK/Abstractions/IPublishingPlatformResiliencePipeline.cs
+++ b/src/PublishingPlatform.SDK/Abstractions/IPublishingPlatformResiliencePipeline.cs
@@ -3,6 +3,7 @@ namespace PublishingPlatform.SDK.Abstractions;
 public interface IPublishingPlatformResiliencePipeline
 {
     Task<HttpResponseMessage> ExecuteAsync(
+        PublishingPlatformResilienceContext context,
         Func<CancellationToken, Task<HttpResponseMessage>> operation,
         CancellationToken cancellationToken = default);
 }

--- a/src/PublishingPlatform.SDK/Abstractions/PublishingPlatformResilienceContext.cs
+++ b/src/PublishingPlatform.SDK/Abstractions/PublishingPlatformResilienceContext.cs
@@ -1,0 +1,6 @@
+namespace PublishingPlatform.SDK.Abstractions;
+
+public sealed class PublishingPlatformResilienceContext
+{
+    public required HttpMethod Method { get; init; }
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransport.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransport.cs
@@ -32,33 +32,38 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
         HttpContent? content,
         CancellationToken cancellationToken = default)
     {
-        return await _resiliencePipeline.ExecuteAsync(
+        var correlationId = _correlationIdProvider.Create();
+        var response = await _resiliencePipeline.ExecuteAsync(
+            new PublishingPlatformResilienceContext
+            {
+                Method = method,
+            },
             async ct =>
             {
-                using var request = BuildRequest(method, relativePath, content);
-                var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
-                if (!response.IsSuccessStatusCode)
-                {
-                    var message = await ReadErrorMessageAsync(response, ct).ConfigureAwait(false);
-                    request.Headers.TryGetValues(CorrelationHeaderName, out var correlationValues);
-                    var context = new PublishingPlatformErrorContext
-                    {
-                        Method = method,
-                        RelativePath = relativePath,
-                        StatusCode = (int)response.StatusCode,
-                        Message = message,
-                        CorrelationId = correlationValues?.FirstOrDefault(),
-                    };
-
-                    throw _errorMapper.Map(context);
-                }
-
-                return response;
+                using var request = BuildRequest(method, relativePath, content, correlationId);
+                return await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
             },
             cancellationToken).ConfigureAwait(false);
+
+        if (response.IsSuccessStatusCode)
+        {
+            return response;
+        }
+
+        var message = await ReadErrorMessageAsync(response, cancellationToken).ConfigureAwait(false);
+        var context = new PublishingPlatformErrorContext
+        {
+            Method = method,
+            RelativePath = relativePath,
+            StatusCode = (int)response.StatusCode,
+            Message = message,
+            CorrelationId = correlationId,
+        };
+
+        throw _errorMapper.Map(context);
     }
 
-    internal HttpRequestMessage BuildRequest(HttpMethod method, string relativePath, HttpContent? content)
+    internal HttpRequestMessage BuildRequest(HttpMethod method, string relativePath, HttpContent? content, string correlationId)
     {
         var request = new HttpRequestMessage(method, relativePath)
         {
@@ -67,7 +72,7 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
 
         if (!request.Headers.Contains(CorrelationHeaderName))
         {
-            request.Headers.Add(CorrelationHeaderName, _correlationIdProvider.Create());
+            request.Headers.Add(CorrelationHeaderName, correlationId);
         }
 
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransport.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransport.cs
@@ -63,7 +63,7 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
         throw _errorMapper.Map(context);
     }
 
-    internal HttpRequestMessage BuildRequest(HttpMethod method, string relativePath, HttpContent? content, string correlationId)
+    internal static HttpRequestMessage BuildRequest(HttpMethod method, string relativePath, HttpContent? content, string correlationId)
     {
         var request = new HttpRequestMessage(method, relativePath)
         {

--- a/src/PublishingPlatform.SDK/Internal/Resilience/DefaultPublishingPlatformResiliencePipeline.cs
+++ b/src/PublishingPlatform.SDK/Internal/Resilience/DefaultPublishingPlatformResiliencePipeline.cs
@@ -6,6 +6,7 @@ namespace PublishingPlatform.SDK.Internal.Resilience;
 internal sealed class DefaultPublishingPlatformResiliencePipeline : IPublishingPlatformResiliencePipeline
 {
     private readonly ResiliencePipeline<HttpResponseMessage> _pipeline;
+    private static readonly ResiliencePropertyKey<HttpMethod> HttpMethodKey = new("PublishingPlatform.HttpMethod");
 
     internal DefaultPublishingPlatformResiliencePipeline(ResiliencePipeline<HttpResponseMessage> pipeline)
     {
@@ -13,11 +14,37 @@ internal sealed class DefaultPublishingPlatformResiliencePipeline : IPublishingP
     }
 
     public async Task<HttpResponseMessage> ExecuteAsync(
+        PublishingPlatformResilienceContext context,
         Func<CancellationToken, Task<HttpResponseMessage>> operation,
         CancellationToken cancellationToken = default)
     {
-        return await _pipeline.ExecuteAsync(
-            async token => await operation(token).ConfigureAwait(false),
-            cancellationToken).ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(operation);
+
+        var resilienceContext = ResilienceContextPool.Shared.Get(cancellationToken);
+        resilienceContext.Properties.Set(HttpMethodKey, context.Method);
+
+        try
+        {
+            return await _pipeline.ExecuteAsync(
+                async token => await operation(token.CancellationToken).ConfigureAwait(false),
+                resilienceContext).ConfigureAwait(false);
+        }
+        finally
+        {
+            ResilienceContextPool.Shared.Return(resilienceContext);
+        }
+    }
+
+    internal static bool TryGetHttpMethod(ResilienceContext context, out HttpMethod method)
+    {
+        if (context.Properties.TryGetValue(HttpMethodKey, out var resolvedMethod) && resolvedMethod is not null)
+        {
+            method = resolvedMethod;
+            return true;
+        }
+
+        method = HttpMethod.Get;
+        return false;
     }
 }

--- a/src/PublishingPlatform.SDK/Internal/Resilience/NoOpPublishingPlatformResiliencePipeline.cs
+++ b/src/PublishingPlatform.SDK/Internal/Resilience/NoOpPublishingPlatformResiliencePipeline.cs
@@ -5,9 +5,11 @@ namespace PublishingPlatform.SDK.Internal.Resilience;
 internal sealed class NoOpPublishingPlatformResiliencePipeline : IPublishingPlatformResiliencePipeline
 {
     public Task<HttpResponseMessage> ExecuteAsync(
+        PublishingPlatformResilienceContext context,
         Func<CancellationToken, Task<HttpResponseMessage>> operation,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(context);
         return operation(cancellationToken);
     }
 }

--- a/src/PublishingPlatform.SDK/Internal/Resilience/ResiliencePipelineFactory.cs
+++ b/src/PublishingPlatform.SDK/Internal/Resilience/ResiliencePipelineFactory.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using Microsoft.Extensions.Http.Resilience;
 using Polly;
+using Polly.Retry;
 using Polly.CircuitBreaker;
 using Polly.Timeout;
 using PublishingPlatform.SDK.Abstractions;
@@ -35,15 +36,7 @@ internal static class ResiliencePipelineFactory
                 Delay = options.Retry.BaseDelay,
                 BackoffType = DelayBackoffType.Exponential,
                 UseJitter = true,
-                ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
-                    .Handle<HttpRequestException>()
-                    .Handle<TimeoutRejectedException>()
-                    .Handle<BrokenCircuitException>()
-                    .HandleResult(response => response.StatusCode is
-                        HttpStatusCode.TooManyRequests or
-                        HttpStatusCode.ServiceUnavailable or
-                        HttpStatusCode.BadGateway or
-                        HttpStatusCode.GatewayTimeout),
+                ShouldHandle = args => new ValueTask<bool>(ShouldRetry(args, options.Retry.RetryNonIdempotentMethods)),
             });
         }
 
@@ -67,6 +60,79 @@ internal static class ResiliencePipelineFactory
         }
 
         return new DefaultPublishingPlatformResiliencePipeline(builder.Build());
+    }
+
+    private static bool ShouldRetry(RetryPredicateArguments<HttpResponseMessage> args, bool retryNonIdempotentMethods)
+    {
+        if (args.Outcome.Exception is HttpRequestException or TimeoutRejectedException or BrokenCircuitException)
+        {
+            return IsMethodAllowed(args.Context, retryNonIdempotentMethods);
+        }
+
+        if (args.Outcome.Result is null)
+        {
+            return false;
+        }
+
+        if (!DefaultPublishingPlatformResiliencePipeline.TryGetHttpMethod(args.Context, out var method))
+        {
+            return false;
+        }
+
+        if (!IsMethodAllowed(method, retryNonIdempotentMethods))
+        {
+            return false;
+        }
+
+        return IsTransientStatusCode(args.Outcome.Result.StatusCode, IsNonIdempotentRetryCandidate(method));
+    }
+
+    private static bool IsMethodAllowed(ResilienceContext context, bool retryNonIdempotentMethods)
+    {
+        if (!DefaultPublishingPlatformResiliencePipeline.TryGetHttpMethod(context, out var method))
+        {
+            return false;
+        }
+
+        return IsMethodAllowed(method, retryNonIdempotentMethods);
+    }
+
+    private static bool IsMethodAllowed(HttpMethod method, bool retryNonIdempotentMethods)
+    {
+        if (IsIdempotentMethod(method))
+        {
+            return true;
+        }
+
+        return retryNonIdempotentMethods && IsNonIdempotentRetryCandidate(method);
+    }
+
+    private static bool IsIdempotentMethod(HttpMethod method)
+    {
+        return method == HttpMethod.Get
+            || method == HttpMethod.Put
+            || method == HttpMethod.Delete
+            || method == HttpMethod.Head
+            || method == HttpMethod.Options
+            || method.Method.Equals("TRACE", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsNonIdempotentRetryCandidate(HttpMethod method)
+    {
+        return method == HttpMethod.Post || method == HttpMethod.Patch;
+    }
+
+    private static bool IsTransientStatusCode(HttpStatusCode statusCode, bool isNonIdempotentMethod)
+    {
+        if (isNonIdempotentMethod)
+        {
+            return statusCode is HttpStatusCode.TooManyRequests or HttpStatusCode.ServiceUnavailable;
+        }
+
+        return statusCode is HttpStatusCode.TooManyRequests
+            or HttpStatusCode.BadGateway
+            or HttpStatusCode.ServiceUnavailable
+            or HttpStatusCode.GatewayTimeout;
     }
 
     private static void Validate(PublishingPlatformResilienceOptions options)

--- a/src/PublishingPlatform.SDK/Options/RetryResilienceOptions.cs
+++ b/src/PublishingPlatform.SDK/Options/RetryResilienceOptions.cs
@@ -7,4 +7,6 @@ public sealed class RetryResilienceOptions
     public int MaxRetryAttempts { get; set; } = 3;
 
     public TimeSpan BaseDelay { get; set; } = TimeSpan.FromMilliseconds(500);
+
+    public bool RetryNonIdempotentMethods { get; set; }
 }

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/ResilienceAndTransportTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/ResilienceAndTransportTests.cs
@@ -8,6 +8,7 @@ using PublishingPlatform.SDK.Infrastructure.Errors;
 using PublishingPlatform.SDK.Infrastructure.Transport;
 using PublishingPlatform.SDK.Internal.Resilience;
 using PublishingPlatform.SDK.Options;
+using System.Net;
 using System.Net.Http.Json;
 
 namespace PublishingPlatform.SDK.Tests.Infrastructure;
@@ -90,11 +91,13 @@ public sealed class ResilienceAndTransportTests
     {
         var tokenSource = new CancellationTokenSource();
         var capturedToken = CancellationToken.None;
+        PublishingPlatformResilienceContext? capturedContext = null;
 
         var pipeline = Substitute.For<IPublishingPlatformResiliencePipeline>();
-        pipeline.ExecuteAsync(Arg.Any<Func<CancellationToken, Task<HttpResponseMessage>>>(), Arg.Any<CancellationToken>())
+        pipeline.ExecuteAsync(Arg.Any<PublishingPlatformResilienceContext>(), Arg.Any<Func<CancellationToken, Task<HttpResponseMessage>>>(), Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
+                capturedContext = callInfo.Arg<PublishingPlatformResilienceContext>();
                 capturedToken = callInfo.Arg<CancellationToken>();
                 var operation = callInfo.Arg<Func<CancellationToken, Task<HttpResponseMessage>>>();
                 return operation(capturedToken);
@@ -107,6 +110,8 @@ public sealed class ResilienceAndTransportTests
         await transport.SendAsync(HttpMethod.Get, "/books", null, tokenSource.Token);
 
         capturedToken.Should().Be(tokenSource.Token);
+        capturedContext.Should().NotBeNull();
+        capturedContext!.Method.Should().Be(HttpMethod.Get);
     }
 
     [Fact]
@@ -312,6 +317,232 @@ public sealed class ResilienceAndTransportTests
             .WithMessage("*BaseDelay*");
     }
 
+    [Fact]
+    public async Task CreatePipeline_RetriesTransientStatusCodes_ForIdempotentMethod()
+    {
+        var options = new PublishingPlatformResilienceOptions
+        {
+            Enabled = true,
+            Retry = new RetryResilienceOptions
+            {
+                Enabled = true,
+                MaxRetryAttempts = 2,
+                BaseDelay = TimeSpan.FromMilliseconds(1),
+            },
+        };
+
+        var pipeline = ResiliencePipelineFactory.Create(options);
+        var attempts = 0;
+
+        var response = await pipeline.ExecuteAsync(
+            new PublishingPlatformResilienceContext { Method = HttpMethod.Get },
+            _ =>
+            {
+                attempts++;
+                return Task.FromResult(new HttpResponseMessage(
+                    attempts < 3 ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.OK));
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        attempts.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task CreatePipeline_DoesNotRetryTransientStatusCodes_ForPostByDefault()
+    {
+        var options = new PublishingPlatformResilienceOptions
+        {
+            Enabled = true,
+            Retry = new RetryResilienceOptions
+            {
+                Enabled = true,
+                MaxRetryAttempts = 2,
+                BaseDelay = TimeSpan.FromMilliseconds(1),
+            },
+        };
+
+        var pipeline = ResiliencePipelineFactory.Create(options);
+        var attempts = 0;
+
+        var response = await pipeline.ExecuteAsync(
+            new PublishingPlatformResilienceContext { Method = HttpMethod.Post },
+            _ =>
+            {
+                attempts++;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        attempts.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CreatePipeline_RetriesTransientStatusCodes_ForPostWhenEnabled()
+    {
+        var options = new PublishingPlatformResilienceOptions
+        {
+            Enabled = true,
+            Retry = new RetryResilienceOptions
+            {
+                Enabled = true,
+                RetryNonIdempotentMethods = true,
+                MaxRetryAttempts = 2,
+                BaseDelay = TimeSpan.FromMilliseconds(1),
+            },
+        };
+
+        var pipeline = ResiliencePipelineFactory.Create(options);
+        var attempts = 0;
+
+        var response = await pipeline.ExecuteAsync(
+            new PublishingPlatformResilienceContext { Method = HttpMethod.Post },
+            _ =>
+            {
+                attempts++;
+                return Task.FromResult(new HttpResponseMessage(
+                    attempts < 3 ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.OK));
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        attempts.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task CreatePipeline_DoesNotRetryNonTransientStatusCodes_ForIdempotentMethod()
+    {
+        var options = new PublishingPlatformResilienceOptions
+        {
+            Enabled = true,
+            Retry = new RetryResilienceOptions
+            {
+                Enabled = true,
+                MaxRetryAttempts = 2,
+                BaseDelay = TimeSpan.FromMilliseconds(1),
+            },
+        };
+
+        var pipeline = ResiliencePipelineFactory.Create(options);
+        var attempts = 0;
+
+        var response = await pipeline.ExecuteAsync(
+            new PublishingPlatformResilienceContext { Method = HttpMethod.Get },
+            _ =>
+            {
+                attempts++;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest));
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        attempts.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CreatePipeline_DoesNotRetryBadGateway_ForPostWhenEnabled()
+    {
+        var options = new PublishingPlatformResilienceOptions
+        {
+            Enabled = true,
+            Retry = new RetryResilienceOptions
+            {
+                Enabled = true,
+                RetryNonIdempotentMethods = true,
+                MaxRetryAttempts = 2,
+                BaseDelay = TimeSpan.FromMilliseconds(1),
+            },
+        };
+
+        var pipeline = ResiliencePipelineFactory.Create(options);
+        var attempts = 0;
+
+        var response = await pipeline.ExecuteAsync(
+            new PublishingPlatformResilienceContext { Method = HttpMethod.Post },
+            _ =>
+            {
+                attempts++;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadGateway));
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadGateway);
+        attempts.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SendAsync_RetriesBeforeErrorMapping_WhenPipelineRetries()
+    {
+        var options = new PublishingPlatformResilienceOptions
+        {
+            Enabled = true,
+            Retry = new RetryResilienceOptions
+            {
+                Enabled = true,
+                MaxRetryAttempts = 2,
+                BaseDelay = TimeSpan.FromMilliseconds(1),
+            },
+        };
+
+        var attempts = 0;
+        using var handler = new RecordingHandler((_, _) =>
+        {
+            attempts++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+            {
+                Content = JsonContent.Create(new { Message = "busy" }),
+            });
+        });
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.test") };
+        var mapper = Substitute.For<IPublishingPlatformErrorMapper>();
+        mapper.Map(Arg.Any<PublishingPlatformErrorContext>()).Returns(new InvalidOperationException("mapped"));
+        var transport = new SharedHttpTransport(
+            httpClient,
+            ResiliencePipelineFactory.Create(options),
+            new FixedCorrelationIdProvider(Faker.Random.Guid().ToString("N")),
+            mapper);
+
+        Func<Task> act = async () => await transport.SendAsync(HttpMethod.Get, "/books", null);
+
+        _ = await act.Should().ThrowAsync<InvalidOperationException>();
+        attempts.Should().Be(3);
+        mapper.Received(1).Map(Arg.Any<PublishingPlatformErrorContext>());
+    }
+
+    [Fact]
+    public async Task SendAsync_UsesStableCorrelationIdAcrossRetries()
+    {
+        var options = new PublishingPlatformResilienceOptions
+        {
+            Enabled = true,
+            Retry = new RetryResilienceOptions
+            {
+                Enabled = true,
+                MaxRetryAttempts = 2,
+                BaseDelay = TimeSpan.FromMilliseconds(1),
+            },
+        };
+
+        var observedCorrelationIds = new List<string>();
+        using var handler = new RecordingHandler((request, _) =>
+        {
+            request.Headers.TryGetValues(SharedHttpTransport.CorrelationHeaderName, out var values).Should().BeTrue();
+            observedCorrelationIds.Add(values!.Single());
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+            {
+                Content = JsonContent.Create(new { Message = "busy" }),
+            });
+        });
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.test") };
+        var transport = new SharedHttpTransport(
+            httpClient,
+            ResiliencePipelineFactory.Create(options),
+            new FixedCorrelationIdProvider("fixed-correlation-id"),
+            new DefaultPublishingPlatformErrorMapper());
+
+        Func<Task> act = async () => await transport.SendAsync(HttpMethod.Get, "/books", null);
+
+        _ = await act.Should().ThrowAsync<ApiException>();
+        observedCorrelationIds.Should().HaveCount(3);
+        observedCorrelationIds.Should().OnlyContain(id => id == "fixed-correlation-id");
+    }
+
     [Theory]
     [InlineData(0d)]
     [InlineData(-0.1d)]
@@ -401,7 +632,7 @@ public sealed class ResilienceAndTransportTests
     private static IPublishingPlatformResiliencePipeline BuildPassThroughPipeline()
     {
         var pipeline = Substitute.For<IPublishingPlatformResiliencePipeline>();
-        pipeline.ExecuteAsync(Arg.Any<Func<CancellationToken, Task<HttpResponseMessage>>>(), Arg.Any<CancellationToken>())
+        pipeline.ExecuteAsync(Arg.Any<PublishingPlatformResilienceContext>(), Arg.Any<Func<CancellationToken, Task<HttpResponseMessage>>>(), Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
                 var operation = callInfo.Arg<Func<CancellationToken, Task<HttpResponseMessage>>>();


### PR DESCRIPTION
## Commit Message

`feat(resilience): add operation-aware retry policy with opt-in POST/PATCH retries`

## PR Summary

- Implemented operation-aware retry behavior using HTTP method context in the resilience pipeline.
- Added `RetryNonIdempotentMethods` (default `false`) to keep POST/PATCH retries explicit and opt-in.
- Refactored transport to apply error mapping only after retries are exhausted and keep correlation ID stable across attempts.
- Added/updated unit tests for idempotent vs non-idempotent retry behavior, transient vs non-transient handling, cancellation propagation, and transport retry/mapping flow.
- Updated README and added retry policy examples in `examples/RetryPolicy`.
