### PR TITLE
RPS-8 feat!: implement books lifecycle client with validation, paging, and internal payload mapping

### DIFF
--- a/.codex/skills/rps-developer-skill/SKILL.md
+++ b/.codex/skills/rps-developer-skill/SKILL.md
@@ -40,6 +40,17 @@ Use this skill when implementing or refactoring production SDK code, public abst
 - Keep exactly one class per file.
 - Treat public, non-base implementations as SDK building blocks with self-documenting naming.
 
+## Naming Convention Rules
+
+- Public SDK contracts must use consumer-friendly names:
+  - command/query inputs: `*Request`
+  - explicit outputs/envelopes: `*Response` (when needed)
+  - core domain entities: clear nouns (for example `Book`).
+- Internal provider wire models must not leak into public surface:
+  - prefer `*Payload` for provider JSON/wire shapes
+  - provider-specific names must stay internal only.
+- Avoid exposing `*Dto` types as public SDK contracts.
+
 ## XML Documentation Requirement
 
 - Add XML documentation comments to all classes, interfaces, properties, and members (private and public).
@@ -53,14 +64,14 @@ Use this skill when implementing or refactoring production SDK code, public abst
 Use explicit static extension mapping.
 
 ```csharp
-public static class BookDtoMappingExtensions
+public static class BookPayloadMappingExtensions
 {
-    public static Book ToDomain(this BookDto dto)
+    public static Book ToDomain(this BookPayload payload)
     {
         return new Book(
-            id: dto.Id,
-            title: dto.Title,
-            author: dto.Author);
+            id: payload.Id,
+            title: payload.Title,
+            author: payload.Author);
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -53,6 +53,45 @@ var client = PublishingPlatformClientBuilder.Create(new PublishingPlatformClient
 }).Build();
 ```
 
+## Books lifecycle usage
+
+```csharp
+using PublishingPlatform.SDK.Models;
+
+var created = await client.Books.CreateAsync(new CreateBookRequest
+{
+    Title = "Domain-Driven Design",
+    Author = "Eric Evans",
+    Tags = new[] { "architecture", "ddd" },
+    IdempotencyKey = "create-book-001"
+});
+
+var loaded = await client.Books.GetByIdAsync(created.Id);
+
+var page = await client.Books.ListAsync(new ListBooksRequest
+{
+    Author = "Eric Evans",
+    SortBy = "title",
+    Descending = false,
+    Page = 0,
+    PageSize = 20
+});
+
+var updated = await client.Books.UpdateMetadataAsync(
+    created.Id,
+    new UpdateBookMetadataRequest
+    {
+        Title = "Domain-Driven Design (Updated)",
+        Author = created.Author,
+        Tags = created.Tags,
+        ConcurrencyToken = created.ConcurrencyToken
+    });
+
+await client.Books.DeleteAsync(updated.Id);
+```
+
+For advanced pagination ergonomics, use `ListAllAsync(...)` to stream all results.
+
 ## Opt-in resilience configuration
 
 Resilience is disabled by default. Enable only the strategies you need.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,6 +59,12 @@ The query surface is planned as an SDK-owned API, for example an `IBookQueryClie
 
 Google Books API may be used as an internal adapter or search source. It must not become a public provider abstraction or leak Google-specific wire shapes into the SDK surface.
 
+Current implementation direction:
+
+- `IBooksClient` remains the public platform-owned contract.
+- Google Books integration is represented only by internal adapter seams and internal DTO-to-model mappings.
+- API key oriented Google volume enrichment is prepared internally; OAuth-only mylibrary flows stay deferred.
+
 The first SDK-focused search flow should combine local uploaded files with external book discovery data behind one SDK search API:
 
 ```text

--- a/examples/BooksLifecycle/BooksLifecycleExample.csx
+++ b/examples/BooksLifecycle/BooksLifecycleExample.csx
@@ -1,0 +1,39 @@
+//r "nuget: PublishingPlatform.SDK"
+
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Options;
+
+var client = PublishingPlatformClientBuilder.Create(new PublishingPlatformClientOptions
+{
+    BaseUrl = "https://api.books.example",
+    ApiKey = "your-api-key",
+}).Build();
+
+var created = await client.Books.CreateAsync(new CreateBookRequest
+{
+    Title = "The Pragmatic Programmer",
+    Author = "Andy Hunt",
+    Tags = new[] { "software", "craft" },
+    IdempotencyKey = "books-create-1",
+});
+
+Console.WriteLine($"Created: {created.Id} - {created.Title}");
+
+var listed = await client.Books.ListAsync(new ListBooksRequest
+{
+    SortBy = "title",
+    Page = 0,
+    PageSize = 10,
+});
+
+Console.WriteLine($"Page returned {listed.Items.Count} books.");
+
+await client.Books.PatchMetadataAsync(created.Id, new UpdateBookPatchRequest
+{
+    Title = "The Pragmatic Programmer (20th Anniversary Edition)",
+    ConcurrencyToken = created.ConcurrencyToken,
+});
+
+await client.Books.DeleteAsync(created.Id);
+Console.WriteLine("Deleted created sample book.");

--- a/examples/BooksLifecycle/README.md
+++ b/examples/BooksLifecycle/README.md
@@ -1,0 +1,10 @@
+# Books Lifecycle Example
+
+This example shows end-to-end usage of the `IBooksClient` contract:
+
+- create a book with idempotency key support
+- list books with paging input
+- apply partial metadata update with optimistic concurrency token
+- delete a book
+
+Run `BooksLifecycleExample.csx` in a C# script environment after setting a valid API base URL and API key.

--- a/src/PublishingPlatform.SDK/Abstractions/IBooksClient.cs
+++ b/src/PublishingPlatform.SDK/Abstractions/IBooksClient.cs
@@ -1,5 +1,67 @@
-﻿namespace PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Models.Common;
 
+namespace PublishingPlatform.SDK.Abstractions;
+
+/// <summary>
+/// Provides book lifecycle operations for creating, retrieving, listing, updating, and deleting books.
+/// </summary>
 public interface IBooksClient
 {
+    /// <summary>
+    /// Creates a new book entry.
+    /// </summary>
+    /// <param name="request">The create request payload.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The created <see cref="Book"/>.</returns>
+    Task<Book> CreateAsync(CreateBookRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets a book by its unique identifier.
+    /// </summary>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The matching <see cref="Book"/>.</returns>
+    Task<Book> GetByIdAsync(string bookId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists books using filtering, sorting, and pagination criteria.
+    /// </summary>
+    /// <param name="request">The list request criteria.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A paged result of books.</returns>
+    Task<PagedResult<Book>> ListAsync(ListBooksRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Streams books across all pages for the provided list request.
+    /// </summary>
+    /// <param name="request">The list request criteria.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>An async sequence of books.</returns>
+    IAsyncEnumerable<Book> ListAllAsync(ListBooksRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates mutable metadata of a book.
+    /// </summary>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="request">The metadata update payload.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The updated <see cref="Book"/>.</returns>
+    Task<Book> UpdateMetadataAsync(string bookId, UpdateBookMetadataRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Partially updates mutable metadata of a book.
+    /// </summary>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="request">The patch payload.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The updated <see cref="Book"/>.</returns>
+    Task<Book> PatchMetadataAsync(string bookId, UpdateBookPatchRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Deletes a book by its unique identifier.
+    /// </summary>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="ct">The cancellation token.</param>
+    Task DeleteAsync(string bookId, CancellationToken ct = default);
 }

--- a/src/PublishingPlatform.SDK/Clients/BooksClient.cs
+++ b/src/PublishingPlatform.SDK/Clients/BooksClient.cs
@@ -1,14 +1,305 @@
+using System.Diagnostics;
+using System.Net.Http.Json;
+using System.Text;
 using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Transport;
+using PublishingPlatform.SDK.Internal;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Models.Common;
 
 namespace PublishingPlatform.SDK.Clients;
 
+/// <summary>
+/// Implements book lifecycle operations using the shared SDK transport.
+/// </summary>
 public sealed class BooksClient : IBooksClient
 {
+    private static readonly HashSet<string> AllowedSortFields = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "title",
+        "author",
+        "createdAt",
+        "updatedAt",
+    };
+
     private readonly ISharedHttpTransport _transport;
 
     internal BooksClient(ISharedHttpTransport transport)
     {
         _transport = transport;
+    }
+
+    /// <inheritdoc />
+    public async Task<Book> CreateAsync(CreateBookRequest request, CancellationToken ct = default)
+    {
+        Guards.NotNull(request, nameof(request));
+        ValidateCreateRequest(request);
+
+        using var activity = StartActivity("Books.Create");
+        var headers = BuildIdempotencyHeaders(request.IdempotencyKey);
+        var content = JsonContent.Create(request);
+        using var response = await _transport.SendAsync(HttpMethod.Post, "/books", content, headers, "Books.Create", ct).ConfigureAwait(false);
+
+        return await ReadBookAsync(response, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<Book> GetByIdAsync(string bookId, CancellationToken ct = default)
+    {
+        ValidateBookId(bookId);
+        using var activity = StartActivity("Books.GetById");
+        using var response = await _transport.SendAsync(HttpMethod.Get, $"/books/{Uri.EscapeDataString(bookId)}", null, null, "Books.GetById", ct).ConfigureAwait(false);
+        return await ReadBookAsync(response, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<PagedResult<Book>> ListAsync(ListBooksRequest request, CancellationToken ct = default)
+    {
+        Guards.NotNull(request, nameof(request));
+        ValidateListRequest(request);
+
+        using var activity = StartActivity("Books.List");
+        var relativePath = BuildListPath(request);
+        using var response = await _transport.SendAsync(HttpMethod.Get, relativePath, null, null, "Books.List", ct).ConfigureAwait(false);
+        return await ReadPagedResultAsync(response, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<Book> ListAllAsync(ListBooksRequest request, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+    {
+        Guards.NotNull(request, nameof(request));
+        ValidateListRequest(request);
+
+        var iterationRequest = CloneRequest(request);
+        while (true)
+        {
+            var page = await ListAsync(iterationRequest, ct).ConfigureAwait(false);
+            foreach (var item in page.Items)
+            {
+                yield return item;
+            }
+
+            if (string.IsNullOrWhiteSpace(page.ContinuationToken))
+            {
+                yield break;
+            }
+
+            iterationRequest.ContinuationToken = page.ContinuationToken;
+            iterationRequest.Page++;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<Book> UpdateMetadataAsync(string bookId, UpdateBookMetadataRequest request, CancellationToken ct = default)
+    {
+        ValidateBookId(bookId);
+        Guards.NotNull(request, nameof(request));
+        ValidateUpdateRequest(request);
+
+        using var activity = StartActivity("Books.UpdateMetadata");
+        var headers = BuildConcurrencyHeaders(request.ConcurrencyToken);
+        var content = JsonContent.Create(request);
+        using var response = await _transport.SendAsync(HttpMethod.Put, $"/books/{Uri.EscapeDataString(bookId)}", content, headers, "Books.UpdateMetadata", ct).ConfigureAwait(false);
+        return await ReadBookAsync(response, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<Book> PatchMetadataAsync(string bookId, UpdateBookPatchRequest request, CancellationToken ct = default)
+    {
+        ValidateBookId(bookId);
+        Guards.NotNull(request, nameof(request));
+        ValidatePatchRequest(request);
+
+        using var activity = StartActivity("Books.PatchMetadata");
+        var headers = BuildConcurrencyHeaders(request.ConcurrencyToken);
+        var content = JsonContent.Create(request);
+        using var response = await _transport.SendAsync(HttpMethod.Patch, $"/books/{Uri.EscapeDataString(bookId)}", content, headers, "Books.PatchMetadata", ct).ConfigureAwait(false);
+        return await ReadBookAsync(response, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteAsync(string bookId, CancellationToken ct = default)
+    {
+        ValidateBookId(bookId);
+        using var activity = StartActivity("Books.Delete");
+        using var _ = await _transport.SendAsync(HttpMethod.Delete, $"/books/{Uri.EscapeDataString(bookId)}", null, null, "Books.Delete", ct).ConfigureAwait(false);
+    }
+
+    private static void ValidateBookId(string bookId)
+    {
+        if (string.IsNullOrWhiteSpace(bookId))
+        {
+            throw new BookValidationException("Book id is required.");
+        }
+    }
+
+    private static void ValidateCreateRequest(CreateBookRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Title))
+        {
+            throw new BookValidationException("Title is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Author))
+        {
+            throw new BookValidationException("Author is required.");
+        }
+    }
+
+    private static void ValidateUpdateRequest(UpdateBookMetadataRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Title))
+        {
+            throw new BookValidationException("Title is required for full metadata update.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Author))
+        {
+            throw new BookValidationException("Author is required for full metadata update.");
+        }
+    }
+
+    private static void ValidatePatchRequest(UpdateBookPatchRequest request)
+    {
+        if (request.Title is null && request.Author is null && request.Tags is null)
+        {
+            throw new BookValidationException("At least one patch field must be provided.");
+        }
+    }
+
+    private static void ValidateListRequest(ListBooksRequest request)
+    {
+        if (request.Page < 0)
+        {
+            throw new BookValidationException("Page must be greater than or equal to zero.");
+        }
+
+        if (request.PageSize is < 1 or > 200)
+        {
+            throw new BookValidationException("PageSize must be between 1 and 200.");
+        }
+
+        if (!AllowedSortFields.Contains(request.SortBy))
+        {
+            throw new BookValidationException($"SortBy must be one of: {string.Join(", ", AllowedSortFields)}.");
+        }
+    }
+
+    private static string BuildListPath(ListBooksRequest request)
+    {
+        var query = new List<KeyValuePair<string, string>>
+        {
+            new("page", request.Page.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+            new("pageSize", request.PageSize.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+            new("sortBy", request.SortBy),
+            new("descending", request.Descending ? "true" : "false"),
+        };
+
+        if (!string.IsNullOrWhiteSpace(request.Title))
+        {
+            query.Add(new("title", request.Title));
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Author))
+        {
+            query.Add(new("author", request.Author));
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.ContinuationToken))
+        {
+            query.Add(new("continuationToken", request.ContinuationToken));
+        }
+
+        foreach (var tag in request.Tags.OrderBy(x => x, StringComparer.Ordinal))
+        {
+            query.Add(new("tag", tag));
+        }
+
+        var builder = new StringBuilder("/books?");
+        for (var i = 0; i < query.Count; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append('&');
+            }
+
+            builder.Append(Uri.EscapeDataString(query[i].Key));
+            builder.Append('=');
+            builder.Append(Uri.EscapeDataString(query[i].Value));
+        }
+
+        return builder.ToString();
+    }
+
+    private static Dictionary<string, string>? BuildIdempotencyHeaders(string? idempotencyKey)
+    {
+        if (string.IsNullOrWhiteSpace(idempotencyKey))
+        {
+            return null;
+        }
+
+        return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Idempotency-Key"] = idempotencyKey,
+        };
+    }
+
+    private static Dictionary<string, string>? BuildConcurrencyHeaders(string? concurrencyToken)
+    {
+        if (string.IsNullOrWhiteSpace(concurrencyToken))
+        {
+            return null;
+        }
+
+        return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["If-Match"] = concurrencyToken,
+        };
+    }
+
+    private static async Task<Book> ReadBookAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        var book = await response.Content.ReadFromJsonAsync<Book>(ct).ConfigureAwait(false);
+        if (book is null)
+        {
+            throw new BookValidationException("Book payload was empty.");
+        }
+
+        return book;
+    }
+
+    private static async Task<PagedResult<Book>> ReadPagedResultAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        var paged = await response.Content.ReadFromJsonAsync<PagedResult<Book>>(ct).ConfigureAwait(false);
+        if (paged is null)
+        {
+            throw new BookValidationException("Paged book payload was empty.");
+        }
+
+        return paged;
+    }
+
+    private static ListBooksRequest CloneRequest(ListBooksRequest request)
+    {
+        return new ListBooksRequest
+        {
+            Title = request.Title,
+            Author = request.Author,
+            Tags = request.Tags.ToArray(),
+            SortBy = request.SortBy,
+            Descending = request.Descending,
+            Page = request.Page,
+            PageSize = request.PageSize,
+            ContinuationToken = request.ContinuationToken,
+        };
+    }
+
+    private static Activity? StartActivity(string operationName)
+    {
+        var activity = ActivitySourceProvider.ActivitySource.StartActivity(operationName, ActivityKind.Client);
+        activity?.SetTag("sdk.operation", operationName);
+        return activity;
     }
 }

--- a/src/PublishingPlatform.SDK/Exceptions/BookConflictException.cs
+++ b/src/PublishingPlatform.SDK/Exceptions/BookConflictException.cs
@@ -1,0 +1,23 @@
+namespace PublishingPlatform.SDK.Exceptions;
+
+/// <summary>
+/// Represents a conflict failure for book mutations.
+/// </summary>
+public sealed class BookConflictException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BookConflictException"/> class.
+    /// </summary>
+    /// <param name="bookId">The book identifier associated with the conflict.</param>
+    /// <param name="message">The failure message.</param>
+    public BookConflictException(string bookId, string message)
+        : base(message)
+    {
+        BookId = bookId;
+    }
+
+    /// <summary>
+    /// Gets the book identifier associated with the conflict.
+    /// </summary>
+    public string BookId { get; }
+}

--- a/src/PublishingPlatform.SDK/Exceptions/BookNotFoundException.cs
+++ b/src/PublishingPlatform.SDK/Exceptions/BookNotFoundException.cs
@@ -1,0 +1,23 @@
+namespace PublishingPlatform.SDK.Exceptions;
+
+/// <summary>
+/// Represents a not found failure for a book resource.
+/// </summary>
+public sealed class BookNotFoundException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BookNotFoundException"/> class.
+    /// </summary>
+    /// <param name="bookId">The missing book identifier.</param>
+    /// <param name="message">The failure message.</param>
+    public BookNotFoundException(string bookId, string message)
+        : base(message)
+    {
+        BookId = bookId;
+    }
+
+    /// <summary>
+    /// Gets the missing book identifier.
+    /// </summary>
+    public string BookId { get; }
+}

--- a/src/PublishingPlatform.SDK/Exceptions/BookRateLimitedException.cs
+++ b/src/PublishingPlatform.SDK/Exceptions/BookRateLimitedException.cs
@@ -1,0 +1,16 @@
+namespace PublishingPlatform.SDK.Exceptions;
+
+/// <summary>
+/// Represents rate limiting failures for book operations.
+/// </summary>
+public sealed class BookRateLimitedException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BookRateLimitedException"/> class.
+    /// </summary>
+    /// <param name="message">The failure message.</param>
+    public BookRateLimitedException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/PublishingPlatform.SDK/Exceptions/BookValidationException.cs
+++ b/src/PublishingPlatform.SDK/Exceptions/BookValidationException.cs
@@ -1,0 +1,16 @@
+namespace PublishingPlatform.SDK.Exceptions;
+
+/// <summary>
+/// Represents validation failures for book requests.
+/// </summary>
+public sealed class BookValidationException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BookValidationException"/> class.
+    /// </summary>
+    /// <param name="message">The validation message.</param>
+    public BookValidationException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/Errors/DefaultPublishingPlatformErrorMapper.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Errors/DefaultPublishingPlatformErrorMapper.cs
@@ -1,4 +1,5 @@
 using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Exceptions;
 
 namespace PublishingPlatform.SDK.Infrastructure.Errors;
 
@@ -6,6 +7,36 @@ internal sealed class DefaultPublishingPlatformErrorMapper : IPublishingPlatform
 {
     public Exception Map(PublishingPlatformErrorContext context)
     {
+        if (context.RelativePath.StartsWith("/books", StringComparison.OrdinalIgnoreCase))
+        {
+            if (context.StatusCode == 404)
+            {
+                return new BookNotFoundException(ExtractBookId(context.RelativePath), context.Message);
+            }
+
+            if (context.StatusCode is 409 or 412)
+            {
+                return new BookConflictException(ExtractBookId(context.RelativePath), context.Message);
+            }
+
+            if (context.StatusCode == 429)
+            {
+                return new BookRateLimitedException(context.Message);
+            }
+        }
+
         return ErrorMapper.Map(context.StatusCode, context.Message);
+    }
+
+    private static string ExtractBookId(string relativePath)
+    {
+        var path = relativePath.Trim('/');
+        var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length < 2)
+        {
+            return string.Empty;
+        }
+
+        return segments[1];
     }
 }

--- a/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/GoogleBooksMappingExtensions.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/GoogleBooksMappingExtensions.cs
@@ -1,0 +1,24 @@
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Infrastructure.GoogleBooks;
+
+/// <summary>
+/// Provides explicit static mapping helpers from Google payloads to SDK models.
+/// </summary>
+internal static class GoogleBooksMappingExtensions
+{
+    /// <summary>
+    /// Maps a Google Books volume payload into a platform <see cref="Book"/> model.
+    /// </summary>
+    /// <param name="payload">The source payload.</param>
+    /// <returns>A mapped <see cref="Book"/> instance.</returns>
+    public static Book ToBook(this GoogleBooksVolumePayload payload)
+    {
+        return new Book
+        {
+            Id = payload.Id,
+            Title = payload.VolumeInfo?.Title ?? string.Empty,
+            Author = payload.VolumeInfo?.Authors?.FirstOrDefault() ?? string.Empty,
+        };
+    }
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/GoogleBooksMappingExtensions.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/GoogleBooksMappingExtensions.cs
@@ -18,7 +18,9 @@ internal static class GoogleBooksMappingExtensions
         {
             Id = payload.Id,
             Title = payload.VolumeInfo?.Title ?? string.Empty,
-            Author = payload.VolumeInfo?.Authors?.FirstOrDefault() ?? string.Empty,
+            Author = payload.VolumeInfo?.Authors is { Count: > 0 } authors
+                ? authors[0]
+                : string.Empty,
         };
     }
 }

--- a/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/GoogleBooksVolumeInfoPayload.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/GoogleBooksVolumeInfoPayload.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace PublishingPlatform.SDK.Infrastructure.GoogleBooks;
+
+/// <summary>
+/// Represents minimal volume info metadata from Google Books.
+/// </summary>
+internal sealed class GoogleBooksVolumeInfoPayload
+{
+    /// <summary>
+    /// Gets or sets the title.
+    /// </summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// Gets or sets author names.
+    /// </summary>
+    [JsonPropertyName("authors")]
+    public IReadOnlyList<string>? Authors { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/GoogleBooksVolumePayload.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/GoogleBooksVolumePayload.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace PublishingPlatform.SDK.Infrastructure.GoogleBooks;
+
+/// <summary>
+/// Represents the minimal Google Books volume payload used for internal enrichment.
+/// </summary>
+internal sealed class GoogleBooksVolumePayload
+{
+    /// <summary>
+    /// Gets or sets the volume identifier.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets nested volume metadata.
+    /// </summary>
+    [JsonPropertyName("volumeInfo")]
+    public GoogleBooksVolumeInfoPayload? VolumeInfo { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/IGoogleBooksVolumesAdapter.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/IGoogleBooksVolumesAdapter.cs
@@ -1,0 +1,17 @@
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Infrastructure.GoogleBooks;
+
+/// <summary>
+/// Represents an internal adapter seam for future Google Books volume enrichment.
+/// </summary>
+internal interface IGoogleBooksVolumesAdapter
+{
+    /// <summary>
+    /// Attempts to enrich a platform book from Google Books data.
+    /// </summary>
+    /// <param name="book">The platform book to enrich.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The enriched book when available; otherwise the original book.</returns>
+    Task<Book> EnrichAsync(Book book, CancellationToken cancellationToken = default);
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/NoOpGoogleBooksVolumesAdapter.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/NoOpGoogleBooksVolumesAdapter.cs
@@ -1,0 +1,15 @@
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Infrastructure.GoogleBooks;
+
+/// <summary>
+/// Default adapter implementation that performs no enrichment.
+/// </summary>
+internal sealed class NoOpGoogleBooksVolumesAdapter : IGoogleBooksVolumesAdapter
+{
+    /// <inheritdoc />
+    public Task<Book> EnrichAsync(Book book, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(book);
+    }
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/ISharedHttpTransport.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/ISharedHttpTransport.cs
@@ -6,5 +6,7 @@ internal interface ISharedHttpTransport
         HttpMethod method,
         string relativePath,
         HttpContent? content,
+        IReadOnlyDictionary<string, string>? headers = null,
+        string? operationName = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransport.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransport.cs
@@ -85,12 +85,9 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
 
         if (headers is not null)
         {
-            foreach (var header in headers)
+            foreach (var header in headers.Where(x => !request.Headers.TryAddWithoutValidation(x.Key, x.Value)))
             {
-                if (!request.Headers.TryAddWithoutValidation(header.Key, header.Value))
-                {
-                    request.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value);
-                }
+                request.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value);
             }
         }
 

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransport.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransport.cs
@@ -30,6 +30,8 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
         HttpMethod method,
         string relativePath,
         HttpContent? content,
+        IReadOnlyDictionary<string, string>? headers = null,
+        string? operationName = null,
         CancellationToken cancellationToken = default)
     {
         var correlationId = _correlationIdProvider.Create();
@@ -40,7 +42,7 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
             },
             async ct =>
             {
-                using var request = BuildRequest(method, relativePath, content, correlationId);
+                using var request = BuildRequest(method, relativePath, content, correlationId, headers);
                 return await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
             },
             cancellationToken).ConfigureAwait(false);
@@ -58,12 +60,18 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
             StatusCode = (int)response.StatusCode,
             Message = message,
             CorrelationId = correlationId,
+            OperationName = operationName,
         };
 
         throw _errorMapper.Map(context);
     }
 
-    internal static HttpRequestMessage BuildRequest(HttpMethod method, string relativePath, HttpContent? content, string correlationId)
+    internal static HttpRequestMessage BuildRequest(
+        HttpMethod method,
+        string relativePath,
+        HttpContent? content,
+        string correlationId,
+        IReadOnlyDictionary<string, string>? headers = null)
     {
         var request = new HttpRequestMessage(method, relativePath)
         {
@@ -73,6 +81,17 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
         if (!request.Headers.Contains(CorrelationHeaderName))
         {
             request.Headers.Add(CorrelationHeaderName, correlationId);
+        }
+
+        if (headers is not null)
+        {
+            foreach (var header in headers)
+            {
+                if (!request.Headers.TryAddWithoutValidation(header.Key, header.Value))
+                {
+                    request.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+            }
         }
 
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/PublishingPlatform.SDK/Models/CreateBookRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/CreateBookRequest.cs
@@ -1,0 +1,27 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents input data required to create a book.
+/// </summary>
+public sealed class CreateBookRequest
+{
+    /// <summary>
+    /// Gets or sets the title of the book.
+    /// </summary>
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the author name.
+    /// </summary>
+    public string Author { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets optional tags for categorization.
+    /// </summary>
+    public IReadOnlyList<string> Tags { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets or sets an optional idempotency key used to safely retry create requests.
+    /// </summary>
+    public string? IdempotencyKey { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Models/ListBooksRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/ListBooksRequest.cs
@@ -1,0 +1,47 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents filtering, sorting, and pagination criteria for listing books.
+/// </summary>
+public sealed class ListBooksRequest
+{
+    /// <summary>
+    /// Gets or sets a title filter.
+    /// </summary>
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// Gets or sets an author filter.
+    /// </summary>
+    public string? Author { get; set; }
+
+    /// <summary>
+    /// Gets or sets tag filters.
+    /// </summary>
+    public IReadOnlyList<string> Tags { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets or sets the field used for sorting.
+    /// </summary>
+    public string SortBy { get; set; } = "title";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether sorting is descending.
+    /// </summary>
+    public bool Descending { get; set; }
+
+    /// <summary>
+    /// Gets or sets zero-based page index.
+    /// </summary>
+    public int Page { get; set; }
+
+    /// <summary>
+    /// Gets or sets requested page size.
+    /// </summary>
+    public int PageSize { get; set; } = 50;
+
+    /// <summary>
+    /// Gets or sets continuation token when continuing paged reads.
+    /// </summary>
+    public string? ContinuationToken { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Models/UpdateBookMetadataRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/UpdateBookMetadataRequest.cs
@@ -1,32 +1,27 @@
 namespace PublishingPlatform.SDK.Models;
 
 /// <summary>
-/// Represents a book entity managed by the platform.
+/// Represents input data required to update full mutable book metadata.
 /// </summary>
-public sealed class Book
+public sealed class UpdateBookMetadataRequest
 {
     /// <summary>
-    /// Gets or sets the unique identifier.
-    /// </summary>
-    public string Id { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Gets or sets the title.
+    /// Gets or sets the updated title value.
     /// </summary>
     public string Title { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the author.
+    /// Gets or sets the updated author value.
     /// </summary>
     public string Author { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets classification tags.
+    /// Gets or sets updated tags.
     /// </summary>
     public IReadOnlyList<string> Tags { get; set; } = Array.Empty<string>();
 
     /// <summary>
-    /// Gets or sets the optional concurrency token.
+    /// Gets or sets the optimistic concurrency token (for example ETag or version).
     /// </summary>
     public string? ConcurrencyToken { get; set; }
 }

--- a/src/PublishingPlatform.SDK/Models/UpdateBookPatchRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/UpdateBookPatchRequest.cs
@@ -1,0 +1,27 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents partial metadata updates for a book.
+/// </summary>
+public sealed class UpdateBookPatchRequest
+{
+    /// <summary>
+    /// Gets or sets an updated title when provided.
+    /// </summary>
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// Gets or sets an updated author when provided.
+    /// </summary>
+    public string? Author { get; set; }
+
+    /// <summary>
+    /// Gets or sets updated tags when provided.
+    /// </summary>
+    public IReadOnlyList<string>? Tags { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optimistic concurrency token (for example ETag or version).
+    /// </summary>
+    public string? ConcurrencyToken { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Properties/AssemblyInfo.cs
+++ b/src/PublishingPlatform.SDK/Properties/AssemblyInfo.cs
@@ -1,1 +1,2 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("PublishingPlatform.SDK.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/tests/PublishingPlatform.SDK.Tests/Books/BooksClientTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Books/BooksClientTests.cs
@@ -1,14 +1,25 @@
+using Bogus;
 using PublishingPlatform.SDK.Clients;
-using PublishingPlatform.SDK.Options;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Infrastructure.Errors;
+using PublishingPlatform.SDK.Infrastructure.Transport;
+using PublishingPlatform.SDK.Internal.Resilience;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Models.Common;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
 
 namespace PublishingPlatform.SDK.Tests.Books;
 
 public sealed class BooksClientTests
 {
+    private static readonly Faker Faker = new();
+
     [Fact]
     public void BuildClient_ReturnsClientWithAllBookCentricModules()
     {
-        var options = new PublishingPlatformClientOptions
+        var options = new PublishingPlatform.SDK.Options.PublishingPlatformClientOptions
         {
             BaseUrl = "https://example.test",
             ApiKey = "test-key",
@@ -16,14 +27,213 @@ public sealed class BooksClientTests
 
         var client = PublishingPlatformClientBuilder.Create(options).Build();
 
-        Assert.NotNull(client.Books);
-        Assert.NotNull(client.BookContent);
-        Assert.NotNull(client.BookPublishing);
-        Assert.NotNull(client.BookDistribution);
-        Assert.NotNull(client.BookAccess);
-        Assert.NotNull(client.BookAnalytics);
-        Assert.NotNull(client.BookAuditLogs);
-        Assert.NotNull(client.BookAssets);
-        Assert.NotNull(client.Webhooks);
+        client.Books.Should().NotBeNull();
+        client.BookContent.Should().NotBeNull();
+        client.BookPublishing.Should().NotBeNull();
+        client.BookDistribution.Should().NotBeNull();
+        client.BookAccess.Should().NotBeNull();
+        client.BookAnalytics.Should().NotBeNull();
+        client.BookAuditLogs.Should().NotBeNull();
+        client.BookAssets.Should().NotBeNull();
+        client.Webhooks.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task CreateAsync_SendsPost_WithIdempotencyHeaderAndCancellation()
+    {
+        var request = new CreateBookRequest
+        {
+            Title = "T",
+            Author = "A",
+            IdempotencyKey = "idem-1",
+        };
+        var responseBook = new Book { Id = "b1", Title = "T", Author = "A" };
+        var token = new CancellationTokenSource().Token;
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+            HttpMethod.Post,
+            "/books",
+            Arg.Any<HttpContent>(),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            "Books.Create",
+            token).Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(responseBook),
+            }));
+
+        var sut = new BooksClient(transport);
+        var result = await sut.CreateAsync(request, token);
+
+        result.Id.Should().Be("b1");
+        await transport.Received(1).SendAsync(
+            HttpMethod.Post,
+            "/books",
+            Arg.Any<HttpContent>(),
+            Arg.Is<IReadOnlyDictionary<string, string>>(h => h["Idempotency-Key"] == "idem-1"),
+            "Books.Create",
+            token);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task GetByIdAsync_ThrowsBookValidationException_ForInvalidId(string id)
+    {
+        var sut = new BooksClient(Substitute.For<ISharedHttpTransport>());
+
+        var act = async () => await sut.GetByIdAsync(id);
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Book id is required");
+    }
+
+    [Fact]
+    public async Task ListAsync_SerializesQueryDeterministically()
+    {
+        var request = new ListBooksRequest
+        {
+            Title = "Title",
+            Author = "Author",
+            SortBy = "title",
+            Descending = true,
+            Page = 1,
+            PageSize = 20,
+            ContinuationToken = "c-1",
+            Tags = new[] { "zeta", "alpha" },
+        };
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+            Arg.Any<HttpMethod>(),
+            Arg.Any<string>(),
+            null,
+            null,
+            "Books.List",
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new PagedResult<Book> { Items = Array.Empty<Book>() }),
+            }));
+        var sut = new BooksClient(transport);
+
+        _ = await sut.ListAsync(request);
+
+        await transport.Received(1).SendAsync(
+            HttpMethod.Get,
+            "/books?page=1&pageSize=20&sortBy=title&descending=true&title=Title&author=Author&continuationToken=c-1&tag=alpha&tag=zeta",
+            null,
+            null,
+            "Books.List",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PatchMetadataAsync_SendsPatchWithIfMatchHeader()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+            HttpMethod.Patch,
+            "/books/book-1",
+            Arg.Any<HttpContent>(),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            "Books.PatchMetadata",
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new Book { Id = "book-1", Title = "T", Author = "A" }),
+            }));
+        var sut = new BooksClient(transport);
+
+        _ = await sut.PatchMetadataAsync("book-1", new UpdateBookPatchRequest { Title = "X", ConcurrencyToken = "\"etag\"" });
+
+        await transport.Received(1).SendAsync(
+            HttpMethod.Patch,
+            "/books/book-1",
+            Arg.Any<HttpContent>(),
+            Arg.Is<IReadOnlyDictionary<string, string>>(h => h["If-Match"] == "\"etag\""),
+            "Books.PatchMetadata",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListAllAsync_YieldsItemsAcrossPages()
+    {
+        using var handler = new SequenceHandler(new[]
+        {
+            JsonContent.Create(new PagedResult<Book>
+            {
+                Items = new[] { new Book { Id = "1", Title = "A", Author = "A" } },
+                ContinuationToken = "next",
+            }),
+            JsonContent.Create(new PagedResult<Book>
+            {
+                Items = new[] { new Book { Id = "2", Title = "B", Author = "B" } },
+            }),
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.test") };
+        var transport = new SharedHttpTransport(client, new NoOpPublishingPlatformResiliencePipeline(), new FixedCorrelationIdProvider(), new DefaultPublishingPlatformErrorMapper());
+        var sut = new BooksClient(transport);
+
+        var items = new List<Book>();
+        await foreach (var item in sut.ListAllAsync(new ListBooksRequest { SortBy = "title", PageSize = 1 }))
+        {
+            items.Add(item);
+        }
+
+        items.Select(x => x.Id).Should().Equal("1", "2");
+    }
+
+    [Fact]
+    public async Task DefaultErrorMapper_Maps404ToBookNotFound()
+    {
+        using var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = JsonContent.Create(new { Message = "missing" }),
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.test") };
+        var transport = new SharedHttpTransport(client, new NoOpPublishingPlatformResiliencePipeline(), new FixedCorrelationIdProvider(), new DefaultPublishingPlatformErrorMapper());
+        var sut = new BooksClient(transport);
+
+        var act = async () => await sut.GetByIdAsync("book-404");
+
+        _ = await act.Should().ThrowAsync<BookNotFoundException>();
+    }
+
+    private sealed class SequenceHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpContent> _responses;
+
+        public SequenceHandler(IEnumerable<HttpContent> responses)
+        {
+            _responses = new Queue<HttpContent>(responses);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var content = _responses.Dequeue();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+        }
+    }
+
+    private sealed class SingleResponseHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+
+        public SingleResponseHandler(HttpResponseMessage response)
+        {
+            _response = response;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_response);
+        }
+    }
+
+    private sealed class FixedCorrelationIdProvider : ICorrelationIdProvider
+    {
+        public string Create()
+        {
+            return Faker.Random.Guid().ToString("N");
+        }
     }
 }

--- a/tests/PublishingPlatform.SDK.Tests/Books/BooksClientTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Books/BooksClientTests.cs
@@ -198,6 +198,197 @@ public sealed class BooksClientTests
         _ = await act.Should().ThrowAsync<BookNotFoundException>();
     }
 
+    [Fact]
+    public async Task CreateAsync_ThrowsBookValidationException_WhenTitleMissing()
+    {
+        var sut = new BooksClient(Substitute.For<ISharedHttpTransport>());
+
+        var act = async () => await sut.CreateAsync(new CreateBookRequest
+        {
+            Title = " ",
+            Author = "Author",
+        });
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Title is required");
+    }
+
+    [Fact]
+    public async Task CreateAsync_ThrowsBookValidationException_WhenAuthorMissing()
+    {
+        var sut = new BooksClient(Substitute.For<ISharedHttpTransport>());
+
+        var act = async () => await sut.CreateAsync(new CreateBookRequest
+        {
+            Title = "Title",
+            Author = "",
+        });
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Author is required");
+    }
+
+    [Theory]
+    [InlineData(-1, 10, "Page must be greater than or equal to zero")]
+    [InlineData(0, 0, "PageSize must be between 1 and 200")]
+    [InlineData(0, 201, "PageSize must be between 1 and 200")]
+    public async Task ListAsync_ThrowsBookValidationException_ForInvalidPaging(int page, int pageSize, string expectedMessage)
+    {
+        var sut = new BooksClient(Substitute.For<ISharedHttpTransport>());
+
+        var act = async () => await sut.ListAsync(new ListBooksRequest
+        {
+            SortBy = "title",
+            Page = page,
+            PageSize = pageSize,
+        });
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain(expectedMessage);
+    }
+
+    [Fact]
+    public async Task ListAsync_ThrowsBookValidationException_ForUnsupportedSortField()
+    {
+        var sut = new BooksClient(Substitute.For<ISharedHttpTransport>());
+
+        var act = async () => await sut.ListAsync(new ListBooksRequest
+        {
+            SortBy = "rank",
+            Page = 0,
+            PageSize = 20,
+        });
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("SortBy must be one of");
+    }
+
+    [Fact]
+    public async Task PatchMetadataAsync_ThrowsBookValidationException_WhenPatchIsEmpty()
+    {
+        var sut = new BooksClient(Substitute.For<ISharedHttpTransport>());
+
+        var act = async () => await sut.PatchMetadataAsync("book-1", new UpdateBookPatchRequest());
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("At least one patch field must be provided");
+    }
+
+    [Fact]
+    public async Task UpdateMetadataAsync_ThrowsBookValidationException_WhenFullPayloadIsIncomplete()
+    {
+        var sut = new BooksClient(Substitute.For<ISharedHttpTransport>());
+
+        var act = async () => await sut.UpdateMetadataAsync("book-1", new UpdateBookMetadataRequest
+        {
+            Title = "Title",
+            Author = "",
+        });
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Author is required for full metadata update");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_CallsTransportWithExpectedOperation()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+            HttpMethod.Delete,
+            "/books/book-2",
+            null,
+            null,
+            "Books.Delete",
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent)));
+        var sut = new BooksClient(transport);
+
+        await sut.DeleteAsync("book-2");
+
+        await transport.Received(1).SendAsync(
+            HttpMethod.Delete,
+            "/books/book-2",
+            null,
+            null,
+            "Books.Delete",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DefaultErrorMapper_Maps409ToBookConflict()
+    {
+        using var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.Conflict)
+        {
+            Content = JsonContent.Create(new { Message = "conflict" }),
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.test") };
+        var transport = new SharedHttpTransport(client, new NoOpPublishingPlatformResiliencePipeline(), new FixedCorrelationIdProvider(), new DefaultPublishingPlatformErrorMapper());
+        var sut = new BooksClient(transport);
+
+        var act = async () => await sut.UpdateMetadataAsync("book-409", new UpdateBookMetadataRequest
+        {
+            Title = "t",
+            Author = "a",
+        });
+
+        _ = await act.Should().ThrowAsync<BookConflictException>();
+    }
+
+    [Fact]
+    public async Task DefaultErrorMapper_Maps429ToBookRateLimited()
+    {
+        using var handler = new SingleResponseHandler(new HttpResponseMessage((HttpStatusCode)429)
+        {
+            Content = JsonContent.Create(new { Message = "too many requests" }),
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.test") };
+        var transport = new SharedHttpTransport(client, new NoOpPublishingPlatformResiliencePipeline(), new FixedCorrelationIdProvider(), new DefaultPublishingPlatformErrorMapper());
+        var sut = new BooksClient(transport);
+
+        var act = async () => await sut.GetByIdAsync("book-429");
+
+        _ = await act.Should().ThrowAsync<BookRateLimitedException>();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ThrowsBookValidationException_WhenResponsePayloadIsNull()
+    {
+        using var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, "application/json"),
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.test") };
+        var transport = new SharedHttpTransport(client, new NoOpPublishingPlatformResiliencePipeline(), new FixedCorrelationIdProvider(), new DefaultPublishingPlatformErrorMapper());
+        var sut = new BooksClient(transport);
+
+        var act = async () => await sut.GetByIdAsync("book-null");
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Book payload was empty");
+    }
+
+    [Fact]
+    public async Task ListAsync_ThrowsBookValidationException_WhenPagedPayloadIsNull()
+    {
+        using var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, "application/json"),
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.test") };
+        var transport = new SharedHttpTransport(client, new NoOpPublishingPlatformResiliencePipeline(), new FixedCorrelationIdProvider(), new DefaultPublishingPlatformErrorMapper());
+        var sut = new BooksClient(transport);
+
+        var act = async () => await sut.ListAsync(new ListBooksRequest
+        {
+            SortBy = "title",
+            Page = 0,
+            PageSize = 10,
+        });
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Paged book payload was empty");
+    }
+
     private sealed class SequenceHandler : HttpMessageHandler
     {
         private readonly Queue<HttpContent> _responses;

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/ResilienceAndTransportTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/ResilienceAndTransportTests.cs
@@ -37,7 +37,7 @@ public sealed class ResilienceAndTransportTests
         var pipeline = BuildPassThroughPipeline();
         var transport = new SharedHttpTransport(httpClient, pipeline, correlationProvider, new DefaultPublishingPlatformErrorMapper());
 
-        await transport.SendAsync(HttpMethod.Get, "/books", null);
+        await transport.SendAsync(HttpMethod.Get, "/books", null, null, null);
 
         handler.LastRequest.Should().NotBeNull();
         handler.LastRequest!.Headers.Accept.ToString().Should().Contain("application/json");
@@ -60,7 +60,7 @@ public sealed class ResilienceAndTransportTests
 
         var transport = new SharedHttpTransport(httpClient, BuildPassThroughPipeline(), new FixedCorrelationIdProvider(Faker.Random.Guid().ToString("N")), new DefaultPublishingPlatformErrorMapper());
 
-        Func<Task> act = async () => await transport.SendAsync(HttpMethod.Post, "/books", JsonContent.Create(new { Title = "A" }));
+        Func<Task> act = async () => await transport.SendAsync(HttpMethod.Post, "/books", JsonContent.Create(new { Title = "A" }), null, null);
 
         var exception = await act.Should().ThrowAsync<ApiException>();
         exception.Which.StatusCode.Should().Be(400);
@@ -79,7 +79,7 @@ public sealed class ResilienceAndTransportTests
 
         var transport = new SharedHttpTransport(httpClient, BuildPassThroughPipeline(), new FixedCorrelationIdProvider(Faker.Random.Guid().ToString("N")), new DefaultPublishingPlatformErrorMapper());
 
-        Func<Task> act = async () => await transport.SendAsync(HttpMethod.Get, "/books", null);
+        Func<Task> act = async () => await transport.SendAsync(HttpMethod.Get, "/books", null, null, null);
 
         var exception = await act.Should().ThrowAsync<ApiException>();
         exception.Which.StatusCode.Should().Be(500);
@@ -107,7 +107,7 @@ public sealed class ResilienceAndTransportTests
         using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.test") };
         var transport = new SharedHttpTransport(httpClient, pipeline, new FixedCorrelationIdProvider(Faker.Random.Guid().ToString("N")), new DefaultPublishingPlatformErrorMapper());
 
-        await transport.SendAsync(HttpMethod.Get, "/books", null, tokenSource.Token);
+        await transport.SendAsync(HttpMethod.Get, "/books", null, null, null, tokenSource.Token);
 
         capturedToken.Should().Be(tokenSource.Token);
         capturedContext.Should().NotBeNull();
@@ -134,7 +134,7 @@ public sealed class ResilienceAndTransportTests
             new FixedCorrelationIdProvider(correlationId),
             mapper);
 
-        Func<Task> act = async () => await transport.SendAsync(HttpMethod.Get, "/books/42", null);
+        Func<Task> act = async () => await transport.SendAsync(HttpMethod.Get, "/books/42", null, null, null);
 
         var exception = await act.Should().ThrowAsync<InvalidOperationException>();
         exception.Which.Should().BeSameAs(expectedException);
@@ -498,7 +498,7 @@ public sealed class ResilienceAndTransportTests
             new FixedCorrelationIdProvider(Faker.Random.Guid().ToString("N")),
             mapper);
 
-        Func<Task> act = async () => await transport.SendAsync(HttpMethod.Get, "/books", null);
+        Func<Task> act = async () => await transport.SendAsync(HttpMethod.Get, "/books", null, null, null);
 
         _ = await act.Should().ThrowAsync<InvalidOperationException>();
         attempts.Should().Be(3);
@@ -536,7 +536,7 @@ public sealed class ResilienceAndTransportTests
             new FixedCorrelationIdProvider("fixed-correlation-id"),
             new DefaultPublishingPlatformErrorMapper());
 
-        Func<Task> act = async () => await transport.SendAsync(HttpMethod.Get, "/books", null);
+        Func<Task> act = async () => await transport.SendAsync(HttpMethod.Get, "/books", null, null, null);
 
         _ = await act.Should().ThrowAsync<ApiException>();
         observedCorrelationIds.Should().HaveCount(3);


### PR DESCRIPTION
## PR Summary
Adds a production-grade `IBooksClient` (`Create/Get/List/Update/Delete`, patch, and list streaming), strict request validation, typed book exceptions, idempotency/concurrency headers, and updated docs/examples.

Introduces internal Google Books adapter seams with provider wire models renamed to `*Payload`, keeping the public SDK surface provider-agnostic.

Expands tests for books behavior and transport updates.  
Test status: `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal` passed (`47/47`).
