### PR TITLE
RPS-49 feat: implement IBookContentClient from OpenAPI with multipart upload and tests

### DIFF
--- a/.codex/skills/rps-developer-skill/SKILL.md
+++ b/.codex/skills/rps-developer-skill/SKILL.md
@@ -33,6 +33,11 @@ Use this skill when implementing or refactoring production SDK code, public abst
   - Example: avoid `System.Runtime.CompilerServices.EnumeratorCancellation` inline in signatures.
   - Preferred: add the `using` and reference `[EnumeratorCancellation]`.
   - If there is an edge case (for example ambiguity or symbol conflict), explicitly prompt before keeping the fully-qualified form.
+- Always add the required `using` directives for SDK and framework types instead of writing fully-qualified type names in code signatures or method bodies.
+  - Example: avoid `Task<PublishingPlatform.SDK.Models.BookContent>`.
+  - Preferred: add `using PublishingPlatform.SDK.Models;` and write `Task<BookContent>`.
+- If a type name collision exists (for example namespace vs model name), use a `using` alias instead of inline fully-qualified types.
+  - Example: `using BookContentModel = PublishingPlatform.SDK.Models.BookContent;` then use `Task<BookContentModel>`.
 
 ## Mandatory Architecture and Coding Rules
 

--- a/.github/workflows/publish-nuget.yaml
+++ b/.github/workflows/publish-nuget.yaml
@@ -1,9 +1,9 @@
 name: Publish NuGet
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
+  release:
+    types:
+      - published
 
 permissions:
   contents: read
@@ -45,4 +45,4 @@ jobs:
           exit 1
 
       - name: Publish package to NuGet.org
-        run: dotnet nuget push "./artifacts/*.nupkg" --source "https://api.nuget.org/v3/index.json" --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --skip-duplicate
+        run: dotnet nuget push "./artifacts/*.nupkg" --source "https://api.nuget.org/v3/index.json" --api-key "${{ steps.login.outputs.NUGET_API_KEY }}"

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -97,8 +97,8 @@ Automated bump mapping:
    - `Directory.Build.props` version
 5. Maintainer reviews release PR correctness.
 6. Maintainer merges release PR.
-7. Release Please creates a `vX.Y.Z` tag.
-8. Tag-triggered workflow publishes to NuGet.org.
+7. Release Please creates a `vX.Y.Z` tag and GitHub Release.
+8. Release-published workflow publishes to NuGet.org.
 
 ## CI/CD responsibilities
 
@@ -118,7 +118,7 @@ CI/CD automates:
 - changelog updates
 - version updates
 - release tag creation
-- NuGet publish on release tags
+- NuGet publish on published GitHub releases
 
 CI/CD does not:
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
   "include-v-in-tag": true,
   "packages": {
     ".": {
-      "release-type": "go",
+      "release-type": "simple",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         {

--- a/src/PublishingPlatform.SDK/Abstractions/IBookContentClient.cs
+++ b/src/PublishingPlatform.SDK/Abstractions/IBookContentClient.cs
@@ -1,5 +1,26 @@
-﻿namespace PublishingPlatform.SDK.Abstractions;
+namespace PublishingPlatform.SDK.Abstractions;
 
+using PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Provides operations for retrieving and managing book content files.
+/// </summary>
 public interface IBookContentClient
 {
+    /// <summary>
+    /// Gets content metadata for a book.
+    /// </summary>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The book content metadata.</returns>
+    Task<BookContent> GetAsync(string bookId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Uploads or replaces book content for a book.
+    /// </summary>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="request">The upload request.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The updated book content metadata.</returns>
+    Task<BookContent> UploadOrReplaceAsync(string bookId, UploadBookContentRequest request, CancellationToken ct = default);
 }

--- a/src/PublishingPlatform.SDK/Clients/BookContent/Requests/DefaultBookContentRequestHeadersFactory.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookContent/Requests/DefaultBookContentRequestHeadersFactory.cs
@@ -1,0 +1,17 @@
+namespace PublishingPlatform.SDK.Clients.BookContent.Requests;
+
+internal sealed class DefaultBookContentRequestHeadersFactory : IBookContentRequestHeadersFactory
+{
+    public IReadOnlyDictionary<string, string>? CreateIdempotencyHeaders(string? idempotencyKey)
+    {
+        if (string.IsNullOrWhiteSpace(idempotencyKey))
+        {
+            return null;
+        }
+
+        return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Idempotency-Key"] = idempotencyKey,
+        };
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/BookContent/Requests/IBookContentRequestHeadersFactory.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookContent/Requests/IBookContentRequestHeadersFactory.cs
@@ -1,0 +1,6 @@
+namespace PublishingPlatform.SDK.Clients.BookContent.Requests;
+
+internal interface IBookContentRequestHeadersFactory
+{
+    IReadOnlyDictionary<string, string>? CreateIdempotencyHeaders(string? idempotencyKey);
+}

--- a/src/PublishingPlatform.SDK/Clients/BookContent/Serialization/DefaultBookContentMultipartFormFactory.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookContent/Serialization/DefaultBookContentMultipartFormFactory.cs
@@ -1,0 +1,32 @@
+namespace PublishingPlatform.SDK.Clients.BookContent.Serialization;
+
+using System.Net.Http.Headers;
+using PublishingPlatform.SDK.Models;
+
+internal sealed class DefaultBookContentMultipartFormFactory : IBookContentMultipartFormFactory
+{
+    public MultipartFormDataContent Create(UploadBookContentRequest request)
+    {
+        var form = new MultipartFormDataContent();
+
+        var fileContent = new StreamContent(request.File);
+        if (!string.IsNullOrWhiteSpace(request.ContentType))
+        {
+            fileContent.Headers.ContentType = MediaTypeHeaderValue.Parse(request.ContentType);
+        }
+
+        form.Add(fileContent, "file", request.FileName);
+
+        if (!string.IsNullOrWhiteSpace(request.Format))
+        {
+            form.Add(new StringContent(request.Format), "format");
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.IdempotencyKey))
+        {
+            form.Add(new StringContent(request.IdempotencyKey), "idempotencyKey");
+        }
+
+        return form;
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/BookContent/Serialization/DefaultBookContentResponseReader.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookContent/Serialization/DefaultBookContentResponseReader.cs
@@ -1,0 +1,20 @@
+namespace PublishingPlatform.SDK.Clients.BookContent.Serialization;
+
+using System.Net.Http.Json;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Models;
+using BookContentModel = PublishingPlatform.SDK.Models.BookContent;
+
+internal sealed class DefaultBookContentResponseReader : IBookContentResponseReader
+{
+    public async Task<BookContentModel> ReadBookContentAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        var content = await response.Content.ReadFromJsonAsync<BookContentModel>(cancellationToken).ConfigureAwait(false);
+        if (content is null)
+        {
+            throw new BookValidationException("Book content payload was empty.");
+        }
+
+        return content;
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/BookContent/Serialization/IBookContentMultipartFormFactory.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookContent/Serialization/IBookContentMultipartFormFactory.cs
@@ -1,0 +1,8 @@
+namespace PublishingPlatform.SDK.Clients.BookContent.Serialization;
+
+using PublishingPlatform.SDK.Models;
+
+internal interface IBookContentMultipartFormFactory
+{
+    MultipartFormDataContent Create(UploadBookContentRequest request);
+}

--- a/src/PublishingPlatform.SDK/Clients/BookContent/Serialization/IBookContentResponseReader.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookContent/Serialization/IBookContentResponseReader.cs
@@ -1,0 +1,11 @@
+namespace PublishingPlatform.SDK.Clients.BookContent.Serialization;
+
+using System.Net.Http.Json;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Models;
+using BookContentModel = PublishingPlatform.SDK.Models.BookContent;
+
+internal interface IBookContentResponseReader
+{
+    Task<BookContentModel> ReadBookContentAsync(HttpResponseMessage response, CancellationToken cancellationToken);
+}

--- a/src/PublishingPlatform.SDK/Clients/BookContent/Validation/DefaultBookContentRequestValidator.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookContent/Validation/DefaultBookContentRequestValidator.cs
@@ -1,0 +1,49 @@
+namespace PublishingPlatform.SDK.Clients.BookContent.Validation;
+
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Models;
+
+internal sealed class DefaultBookContentRequestValidator : IBookContentRequestValidator
+{
+    private static readonly HashSet<string> AllowedFormats = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "pdf",
+        "epub",
+    };
+
+    public void ValidateBookId(string bookId)
+    {
+        if (string.IsNullOrWhiteSpace(bookId))
+        {
+            throw new BookValidationException("Book id is required.");
+        }
+    }
+
+    public void ValidateUploadRequest(UploadBookContentRequest request)
+    {
+        if (request.File == Stream.Null)
+        {
+            throw new BookValidationException("File stream is required.");
+        }
+
+        if (request.File is null || !request.File.CanRead)
+        {
+            throw new BookValidationException("File stream must be readable.");
+        }
+
+        if (request.File.CanSeek && request.File.Length <= 0)
+        {
+            throw new BookValidationException("File stream must not be empty.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Format) && !AllowedFormats.Contains(request.Format))
+        {
+            throw new BookValidationException($"Format must be one of: {string.Join(", ", AllowedFormats)}.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.FileName))
+        {
+            throw new BookValidationException("File name is required.");
+        }
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/BookContent/Validation/IBookContentRequestValidator.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookContent/Validation/IBookContentRequestValidator.cs
@@ -1,0 +1,10 @@
+namespace PublishingPlatform.SDK.Clients.BookContent.Validation;
+
+using PublishingPlatform.SDK.Models;
+
+internal interface IBookContentRequestValidator
+{
+    void ValidateBookId(string bookId);
+
+    void ValidateUploadRequest(UploadBookContentRequest request);
+}

--- a/src/PublishingPlatform.SDK/Clients/BookContentClient.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookContentClient.cs
@@ -1,14 +1,93 @@
+using System.Diagnostics;
 using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Clients.BookContent.Requests;
+using PublishingPlatform.SDK.Clients.BookContent.Serialization;
+using PublishingPlatform.SDK.Clients.BookContent.Validation;
+using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Transport;
+using PublishingPlatform.SDK.Internal;
+using PublishingPlatform.SDK.Models;
+using BookContentModel = PublishingPlatform.SDK.Models.BookContent;
 
 namespace PublishingPlatform.SDK.Clients;
 
+/// <summary>
+/// Implements book content operations using the shared SDK transport.
+/// </summary>
 public sealed class BookContentClient : IBookContentClient
 {
     private readonly ISharedHttpTransport _transport;
+    private readonly IBookContentRequestValidator _validator;
+    private readonly IBookContentRequestHeadersFactory _requestHeadersFactory;
+    private readonly IBookContentMultipartFormFactory _multipartFormFactory;
+    private readonly IBookContentResponseReader _responseReader;
 
     internal BookContentClient(ISharedHttpTransport transport)
+        : this(
+            transport,
+            new DefaultBookContentRequestValidator(),
+            new DefaultBookContentRequestHeadersFactory(),
+            new DefaultBookContentMultipartFormFactory(),
+            new DefaultBookContentResponseReader())
+    {
+    }
+
+    internal BookContentClient(
+        ISharedHttpTransport transport,
+        IBookContentRequestValidator validator,
+        IBookContentRequestHeadersFactory requestHeadersFactory,
+        IBookContentMultipartFormFactory multipartFormFactory,
+        IBookContentResponseReader responseReader)
     {
         _transport = transport;
+        _validator = validator;
+        _requestHeadersFactory = requestHeadersFactory;
+        _multipartFormFactory = multipartFormFactory;
+        _responseReader = responseReader;
+    }
+
+    /// <inheritdoc />
+    public async Task<BookContentModel> GetAsync(string bookId, CancellationToken ct = default)
+    {
+        _validator.ValidateBookId(bookId);
+
+        using var activity = StartActivity("BookContent.Get");
+        using var response = await _transport.SendAsync(
+            HttpMethod.Get,
+            $"/books/{Uri.EscapeDataString(bookId)}/content",
+            null,
+            null,
+            "BookContent.Get",
+            ct).ConfigureAwait(false);
+
+        return await _responseReader.ReadBookContentAsync(response, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<BookContentModel> UploadOrReplaceAsync(string bookId, UploadBookContentRequest request, CancellationToken ct = default)
+    {
+        _validator.ValidateBookId(bookId);
+        Guards.NotNull(request, nameof(request));
+        _validator.ValidateUploadRequest(request);
+
+        using var activity = StartActivity("BookContent.UploadOrReplace");
+        var headers = _requestHeadersFactory.CreateIdempotencyHeaders(request.IdempotencyKey);
+        using var content = _multipartFormFactory.Create(request);
+        using var response = await _transport.SendAsync(
+            HttpMethod.Put,
+            $"/books/{Uri.EscapeDataString(bookId)}/content",
+            content,
+            headers,
+            "BookContent.UploadOrReplace",
+            ct).ConfigureAwait(false);
+
+        return await _responseReader.ReadBookContentAsync(response, ct).ConfigureAwait(false);
+    }
+
+    private static Activity? StartActivity(string operationName)
+    {
+        var activity = ActivitySourceProvider.ActivitySource.StartActivity(operationName, ActivityKind.Client);
+        activity?.SetTag("sdk.operation", operationName);
+        return activity;
     }
 }

--- a/src/PublishingPlatform.SDK/Clients/Books/Pagination/DefaultBookPaginationIteratorFactory.cs
+++ b/src/PublishingPlatform.SDK/Clients/Books/Pagination/DefaultBookPaginationIteratorFactory.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using PublishingPlatform.SDK.Models;
 using PublishingPlatform.SDK.Models.Common;
 
@@ -8,7 +9,7 @@ internal sealed class DefaultBookPaginationIteratorFactory : IBookPaginationIter
     public async IAsyncEnumerable<Book> IterateAsync(
         ListBooksRequest request,
         Func<ListBooksRequest, CancellationToken, Task<PagedResult<Book>>> pageLoader,
-        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        [EnumeratorCancellation] CancellationToken ct)
     {
         var iterationRequest = CloneRequest(request);
         while (true)

--- a/src/PublishingPlatform.SDK/Models/BookContent.cs
+++ b/src/PublishingPlatform.SDK/Models/BookContent.cs
@@ -1,10 +1,32 @@
-﻿namespace PublishingPlatform.SDK.Models;
+namespace PublishingPlatform.SDK.Models;
 
+/// <summary>
+/// Represents book content metadata.
+/// </summary>
 public sealed class BookContent
 {
+    /// <summary>
+    /// Gets or sets the book identifier associated with the content.
+    /// </summary>
     public string BookId { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Gets or sets the content format.
+    /// </summary>
     public string Format { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Gets or sets the remote content URL when available.
+    /// </summary>
     public Uri? ContentUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the local storage path when available.
+    /// </summary>
+    public string? LocalPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp when content was stored.
+    /// </summary>
+    public DateTimeOffset? StoredAt { get; set; }
 }

--- a/src/PublishingPlatform.SDK/Models/UploadBookContentRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/UploadBookContentRequest.cs
@@ -1,0 +1,32 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents the input required to upload or replace book content.
+/// </summary>
+public sealed class UploadBookContentRequest
+{
+    /// <summary>
+    /// Gets or sets the content stream.
+    /// </summary>
+    public Stream File { get; set; } = Stream.Null;
+
+    /// <summary>
+    /// Gets or sets the uploaded file name sent to the API.
+    /// </summary>
+    public string FileName { get; set; } = "content";
+
+    /// <summary>
+    /// Gets or sets the optional media content type (for example application/pdf).
+    /// </summary>
+    public string? ContentType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional content format (for example pdf or epub).
+    /// </summary>
+    public string? Format { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional idempotency key used to safely retry uploads.
+    /// </summary>
+    public string? IdempotencyKey { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Properties/AssemblyInfo.cs
+++ b/src/PublishingPlatform.SDK/Properties/AssemblyInfo.cs
@@ -1,2 +1,10 @@
+/// <summary>
+/// Exposes SDK internal types and members to the SDK test project so tests can validate
+/// internal behavior without widening the public API surface.
+/// </summary>
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("PublishingPlatform.SDK.Tests")]
+/// <summary>
+/// Exposes SDK internals to Castle DynamicProxy (used by common mocking frameworks) so
+/// tests can create proxies/mocks for internal abstractions.
+/// </summary>
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/tests/PublishingPlatform.SDK.Tests/BookContent/BookContentClientTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/BookContent/BookContentClientTests.cs
@@ -1,0 +1,187 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Infrastructure.Errors;
+using PublishingPlatform.SDK.Infrastructure.Transport;
+using PublishingPlatform.SDK.Internal.Resilience;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Tests.BookContent;
+
+public sealed class BookContentClientTests
+{
+    [Fact]
+    public async Task GetAsync_SendsGetToExpectedPath_WithCancellation()
+    {
+        var token = new CancellationTokenSource().Token;
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+            HttpMethod.Get,
+            "/books/book-1/content",
+            null,
+            null,
+            "BookContent.Get",
+            token).Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new Models.BookContent { BookId = "book-1", Format = "pdf" }),
+            }));
+
+        var sut = new BookContentClient(transport);
+
+        var result = await sut.GetAsync("book-1", token);
+
+        result.BookId.Should().Be("book-1");
+        await transport.Received(1).SendAsync(
+            HttpMethod.Get,
+            "/books/book-1/content",
+            null,
+            null,
+            "BookContent.Get",
+            token);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task GetAsync_ThrowsBookValidationException_ForInvalidBookId(string bookId)
+    {
+        var sut = new BookContentClient(Substitute.For<ISharedHttpTransport>());
+
+        var act = async () => await sut.GetAsync(bookId);
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Book id is required");
+    }
+
+    [Fact]
+    public async Task UploadOrReplaceAsync_SendsPutMultipart_WithIdempotencyHeader()
+    {
+        string? multipartPayload = null;
+        string? multipartContentType = null;
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+                HttpMethod.Put,
+                "/books/book-2/content",
+                Arg.Any<HttpContent>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                "BookContent.UploadOrReplace",
+                Arg.Any<CancellationToken>())
+            .Returns(async call =>
+            {
+                var requestContent = call.ArgAt<HttpContent>(2);
+                multipartContentType = requestContent.Headers.ContentType?.MediaType;
+                multipartPayload = await requestContent.ReadAsStringAsync();
+                return new HttpResponseMessage(HttpStatusCode.Accepted)
+                {
+                    Content = JsonContent.Create(new Models.BookContent { BookId = "book-2", Format = "epub" }),
+                };
+            });
+
+        var sut = new BookContentClient(transport);
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes("sample-content"));
+
+        _ = await sut.UploadOrReplaceAsync("book-2", new UploadBookContentRequest
+        {
+            File = stream,
+            FileName = "book.epub",
+            ContentType = "application/epub+zip",
+            Format = "epub",
+            IdempotencyKey = "idem-2",
+        });
+
+        await transport.Received(1).SendAsync(
+            HttpMethod.Put,
+            "/books/book-2/content",
+            Arg.Any<HttpContent>(),
+            Arg.Is<IReadOnlyDictionary<string, string>>(h => h["Idempotency-Key"] == "idem-2"),
+            "BookContent.UploadOrReplace",
+            Arg.Any<CancellationToken>());
+
+        multipartContentType.Should().Be("multipart/form-data");
+        multipartPayload.Should().NotBeNull();
+        multipartPayload!.Should().Contain("name=file");
+        multipartPayload.Should().Contain("filename=book.epub");
+        multipartPayload.Should().Contain("name=format");
+        multipartPayload.Should().Contain("epub");
+        multipartPayload.Should().Contain("name=idempotencyKey");
+        multipartPayload.Should().Contain("idem-2");
+    }
+
+    [Theory]
+    [InlineData("mobi")]
+    [InlineData("txt")]
+    public async Task UploadOrReplaceAsync_ThrowsBookValidationException_ForUnsupportedFormat(string format)
+    {
+        var sut = new BookContentClient(Substitute.For<ISharedHttpTransport>());
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes("sample-content"));
+
+        var act = async () => await sut.UploadOrReplaceAsync("book-2", new UploadBookContentRequest
+        {
+            File = stream,
+            FileName = "book.bin",
+            Format = format,
+        });
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Format must be one of");
+    }
+
+    [Fact]
+    public async Task UploadOrReplaceAsync_ThrowsBookValidationException_ForEmptyStream()
+    {
+        var sut = new BookContentClient(Substitute.For<ISharedHttpTransport>());
+        await using var stream = new MemoryStream(Array.Empty<byte>());
+
+        var act = async () => await sut.UploadOrReplaceAsync("book-2", new UploadBookContentRequest
+        {
+            File = stream,
+            FileName = "book.pdf",
+            Format = "pdf",
+        });
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("must not be empty");
+    }
+
+    [Fact]
+    public async Task GetAsync_ThrowsBookValidationException_WhenResponsePayloadIsNull()
+    {
+        using var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, "application/json"),
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.test") };
+        var transport = new SharedHttpTransport(client, new NoOpPublishingPlatformResiliencePipeline(), new FixedCorrelationIdProvider(), new DefaultPublishingPlatformErrorMapper());
+        var sut = new BookContentClient(transport);
+
+        var act = async () => await sut.GetAsync("book-null");
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Book content payload was empty");
+    }
+
+    private sealed class SingleResponseHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+
+        public SingleResponseHandler(HttpResponseMessage response)
+        {
+            _response = response;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_response);
+        }
+    }
+
+    private sealed class FixedCorrelationIdProvider : ICorrelationIdProvider
+    {
+        public string Create()
+        {
+            return Guid.NewGuid().ToString("N");
+        }
+    }
+}


### PR DESCRIPTION
## PR Summary

Implements `IBookContentClient` for issue #49 using the OpenAPI contract.

### What’s included
- Added `IBookContentClient` operations:
  - `GetAsync(bookId, ct)`
  - `UploadOrReplaceAsync(bookId, request, ct)`
- Implemented `BookContentClient` with:
  - shared transport usage
  - validation and guard clauses
  - escaped `bookId` path handling
  - idempotency header support
  - multipart/form-data upload (`file`, optional `format`, optional `idempotencyKey`)
  - response parsing and null-payload validation
- Added `UploadBookContentRequest` model.
- Extended `BookContent` model with `LocalPath` and `StoredAt`.
- Added focused BookContent collaborators for:
  - request validation
  - request headers
  - multipart construction
  - response reading
- Added unit tests for:
  - validation failures
  - transport method/path/operation/cancellation
  - idempotency header behavior
  - multipart payload shape
  - null response payload handling

### Additional update
- Updated `rps-developer-skill` guidance to:
  - require `using` directives instead of fully-qualified inline types
  - require alias usage when type/name collisions occur




NOTE: nuget publish process changed to use auto-tag creation process already in place