### PR TITLE
RPS-47 feat!: expand SDK initialization/module documentation and add runnable basic usage examples

### DIFF
--- a/.codex/skills/rps-developer-skill/SKILL.md
+++ b/.codex/skills/rps-developer-skill/SKILL.md
@@ -39,6 +39,10 @@ Use this skill when implementing or refactoring production SDK code, public abst
 - SDK HTTP consumption must be REST-oriented only.
 - Never use AutoMapper.
 - Always use custom manual mapping through static extension methods.
+- Avoid redundant constructor null guards for dependencies resolved exclusively by DI:
+  - Do not add `ArgumentNullException.ThrowIfNull(...)` for DI-only constructor parameters.
+  - Rely on container resolution failures for missing registrations.
+  - Keep null guards for inputs that can come from external/non-DI callers (for example public methods, factory inputs, builder configuration inputs).
 - Do not introduce any new third-party dependency unless the user has explicitly approved it.
 - If a new third-party dependency is approved, use the newest available compatible stable version that does not conflict with existing dependency constraints.
 - Keep exactly one class per file.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,206 @@ var client = PublishingPlatformClientBuilder.Create(new PublishingPlatformClient
 }).Build();
 ```
 
+## Initialization examples
+
+The root client exposes resource-style modules such as:
+
+- `platformClient.Books`
+- `platformClient.BookContent`
+- `platformClient.BookPublishing`
+- `platformClient.Webhooks`
+
+### Direct builder initialization
+
+```csharp
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Options;
+
+var platformClient = PublishingPlatformClientBuilder.Create(new PublishingPlatformClientOptions
+{
+    BaseUrl = "https://api.books.example",
+    ApiKey = "your-api-key",
+    Timeout = TimeSpan.FromSeconds(30)
+}).Build();
+
+var books = platformClient.Books;
+var content = platformClient.BookContent;
+var publishing = platformClient.BookPublishing;
+var webhooks = platformClient.Webhooks;
+```
+
+### DI initialization (ASP.NET Core / host apps)
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Extensions;
+
+var services = new ServiceCollection();
+
+services.AddPublishingPlatformClient(options =>
+{
+    options.BaseUrl = "https://api.books.example";
+    options.ApiKey = "your-api-key";
+    options.Timeout = TimeSpan.FromSeconds(30);
+});
+
+using var provider = services.BuildServiceProvider();
+var platformClient = provider.GetRequiredService<IPublishingPlatformClient>();
+
+var books = platformClient.Books;
+var content = platformClient.BookContent;
+var publishing = platformClient.BookPublishing;
+var webhooks = platformClient.Webhooks;
+```
+
+Runnable scripts are available in:
+
+- `examples/BasicUsage/BuilderInitializationExample.csx`
+- `examples/BasicUsage/DiInitializationExample.csx`
+
+## Client modules: available properties and use cases
+
+`IPublishingPlatformClient` is the SDK root and exposes module clients as properties.
+
+### `Books` (`IBooksClient`)
+
+Primary module for active book lifecycle operations.
+
+Available operations:
+
+- `CreateAsync(...)`: create a new book record.
+- `GetByIdAsync(...)`: retrieve a single book by ID.
+- `ListAsync(...)`: list books with filtering, sorting, and paging.
+- `ListAllAsync(...)`: stream books across all pages as `IAsyncEnumerable<Book>`.
+- `UpdateMetadataAsync(...)`: replace mutable metadata.
+- `PatchMetadataAsync(...)`: partially update mutable metadata.
+- `DeleteAsync(...)`: remove a book by ID.
+
+Typical use cases:
+
+- Catalog ingestion and onboarding of new titles.
+- Internal back-office CRUD flows.
+- Scheduled sync jobs that iterate the full catalog (`ListAllAsync`).
+- Metadata correction workflows with optimistic concurrency tokens.
+
+### `BookContent` (`IBookContentClient`)
+
+Module accessor for book content workflows (for example upload, replacement, or content-related actions).
+
+Current status:
+
+- Property is available on the root client.
+- Interface is currently a placeholder (no public operations yet in this SDK version).
+
+Typical use cases once expanded:
+
+- Uploading source content for books.
+- Replacing or versioning stored content artifacts.
+
+### `BookPublishing` (`IBookPublishingClient`)
+
+Module accessor for publish-oriented workflows.
+
+Current status:
+
+- Property is available on the root client.
+- Interface is currently a placeholder (no public operations yet in this SDK version).
+
+Typical use cases once expanded:
+
+- Triggering publication jobs.
+- Managing publish state transitions.
+
+### `BookDistribution` (`IBookDistributionClient`)
+
+Module accessor for downstream distribution workflows.
+
+Current status:
+
+- Property is available on the root client.
+- Interface is currently a placeholder (no public operations yet in this SDK version).
+
+Typical use cases once expanded:
+
+- Pushing books to channels/partners.
+- Tracking distribution outcome and status.
+
+### `BookAccess` (`IBookAccessClient`)
+
+Module accessor for access-control and entitlement-related workflows.
+
+Current status:
+
+- Property is available on the root client.
+- Interface is currently a placeholder (no public operations yet in this SDK version).
+
+Typical use cases once expanded:
+
+- Access policy assignment.
+- Reader or tenant entitlement operations.
+
+### `BookAnalytics` (`IBookAnalyticsClient`)
+
+Module accessor for analytics and reporting workflows.
+
+Current status:
+
+- Property is available on the root client.
+- Interface is currently a placeholder (no public operations yet in this SDK version).
+
+Typical use cases once expanded:
+
+- Consumption/performance reporting.
+- Title-level engagement insights.
+
+### `BookAuditLogs` (`IBookAuditLogsClient`)
+
+Module accessor for audit trail workflows.
+
+Current status:
+
+- Property is available on the root client.
+- Interface is currently a placeholder (no public operations yet in this SDK version).
+
+Typical use cases once expanded:
+
+- Compliance-oriented activity history.
+- Operational troubleshooting and traceability.
+
+### `BookAssets` (`IBookAssetsClient`)
+
+Module accessor for asset-management workflows.
+
+Current status:
+
+- Property is available on the root client.
+- Interface is currently a placeholder (no public operations yet in this SDK version).
+
+Typical use cases once expanded:
+
+- Managing covers, previews, and supplemental media.
+- Asset lifecycle and replacement flows.
+
+### `Webhooks` (`IWebhooksClient`)
+
+Module accessor for webhook-oriented integration workflows.
+
+Current status:
+
+- Property is available on the root client.
+- Interface is currently a placeholder (no public operations yet in this SDK version).
+
+Typical use cases once expanded:
+
+- Registering callback endpoints.
+- Receiving event notifications for asynchronous platform events.
+
+## Which module should I use?
+
+- Use `Books` today for production book CRUD/listing flows.
+- Use other module properties as stable access points in your codebase while their operation surfaces are being expanded in upcoming SDK iterations.
+
 ## Books lifecycle usage
 
 ```csharp

--- a/examples/BasicUsage/BuilderInitializationExample.csx
+++ b/examples/BasicUsage/BuilderInitializationExample.csx
@@ -1,0 +1,19 @@
+#r "../../src/PublishingPlatform.SDK/bin/Debug/net10.0/PublishingPlatform.SDK.dll"
+
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Options;
+
+var platformClient = PublishingPlatformClientBuilder.Create(new PublishingPlatformClientOptions
+{
+    BaseUrl = "https://api.books.example",
+    ApiKey = "demo-key",
+    Timeout = TimeSpan.FromSeconds(30),
+}).Build();
+
+var books = platformClient.Books;
+var content = platformClient.BookContent;
+var publishing = platformClient.BookPublishing;
+var webhooks = platformClient.Webhooks;
+
+Console.WriteLine($"Client initialized: {platformClient.GetType().Name}");
+Console.WriteLine($"Modules: {nameof(books)}, {nameof(content)}, {nameof(publishing)}, {nameof(webhooks)}");

--- a/examples/BasicUsage/DiInitializationExample.csx
+++ b/examples/BasicUsage/DiInitializationExample.csx
@@ -1,0 +1,26 @@
+#r "../../src/PublishingPlatform.SDK/bin/Debug/net10.0/PublishingPlatform.SDK.dll"
+#r "nuget: Microsoft.Extensions.DependencyInjection, 9.0.0"
+
+using Microsoft.Extensions.DependencyInjection;
+using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Extensions;
+
+var services = new ServiceCollection();
+
+services.AddPublishingPlatformClient(options =>
+{
+    options.BaseUrl = "https://api.books.example";
+    options.ApiKey = "demo-key";
+    options.Timeout = TimeSpan.FromSeconds(30);
+});
+
+using var provider = services.BuildServiceProvider();
+var platformClient = provider.GetRequiredService<IPublishingPlatformClient>();
+
+var books = platformClient.Books;
+var content = platformClient.BookContent;
+var publishing = platformClient.BookPublishing;
+var webhooks = platformClient.Webhooks;
+
+Console.WriteLine($"Client initialized through DI: {platformClient.GetType().Name}");
+Console.WriteLine($"Modules: {nameof(books)}, {nameof(content)}, {nameof(publishing)}, {nameof(webhooks)}");

--- a/examples/BasicUsage/README.md
+++ b/examples/BasicUsage/README.md
@@ -1,3 +1,7 @@
 # Basic Usage
 
-Use `PublishingPlatformClientExample.csx` for a minimal end-to-end setup example with optional resilience.
+Use these scripts for SDK client initialization patterns:
+
+- `PublishingPlatformClientExample.csx`: minimal builder setup with optional resilience.
+- `BuilderInitializationExample.csx`: direct builder initialization with module access.
+- `DiInitializationExample.csx`: DI initialization and module resolution via `IPublishingPlatformClient`.

--- a/src/PublishingPlatform.SDK/Clients/PublishingPlatformClient.cs
+++ b/src/PublishingPlatform.SDK/Clients/PublishingPlatformClient.cs
@@ -3,8 +3,23 @@ using PublishingPlatform.SDK.Infrastructure.Transport;
 
 namespace PublishingPlatform.SDK.Clients;
 
+/// <summary>
+/// Provides orchestration-only access to all Publishing Platform SDK book modules.
+/// </summary>
 public sealed class PublishingPlatformClient : IPublishingPlatformClient
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PublishingPlatformClient"/> class.
+    /// </summary>
+    /// <param name="books">The books module client.</param>
+    /// <param name="bookContent">The book content module client.</param>
+    /// <param name="bookPublishing">The book publishing module client.</param>
+    /// <param name="bookDistribution">The book distribution module client.</param>
+    /// <param name="bookAccess">The book access module client.</param>
+    /// <param name="bookAnalytics">The book analytics module client.</param>
+    /// <param name="bookAuditLogs">The book audit logs module client.</param>
+    /// <param name="bookAssets">The book assets module client.</param>
+    /// <param name="webhooks">The webhooks module client.</param>
     public PublishingPlatformClient(
         IBooksClient books,
         IBookContentClient bookContent,
@@ -45,8 +60,16 @@ public sealed class PublishingPlatformClient : IPublishingPlatformClient
 
     public IWebhooksClient Webhooks { get; }
 
+    /// <summary>
+    /// Creates a fully-wired root client using a shared transport.
+    /// </summary>
+    /// <param name="transport">The shared transport used by all module clients.</param>
+    /// <returns>A concrete <see cref="PublishingPlatformClient"/> instance.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="transport"/> is <see langword="null"/>.</exception>
     internal static PublishingPlatformClient CreateFromTransport(ISharedHttpTransport transport)
     {
+        ArgumentNullException.ThrowIfNull(transport);
+
         return new PublishingPlatformClient(
             new BooksClient(transport),
             new BookContentClient(transport),

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/PublishingPlatformClientTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/PublishingPlatformClientTests.cs
@@ -1,0 +1,71 @@
+using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Infrastructure.Transport;
+
+namespace PublishingPlatform.SDK.Tests.Infrastructure;
+
+public sealed class PublishingPlatformClientTests
+{
+    [Fact]
+    public void Constructor_AssignsModules_WhenAllDependenciesProvided()
+    {
+        var books = Substitute.For<IBooksClient>();
+        var bookContent = Substitute.For<IBookContentClient>();
+        var bookPublishing = Substitute.For<IBookPublishingClient>();
+        var bookDistribution = Substitute.For<IBookDistributionClient>();
+        var bookAccess = Substitute.For<IBookAccessClient>();
+        var bookAnalytics = Substitute.For<IBookAnalyticsClient>();
+        var bookAuditLogs = Substitute.For<IBookAuditLogsClient>();
+        var bookAssets = Substitute.For<IBookAssetsClient>();
+        var webhooks = Substitute.For<IWebhooksClient>();
+
+        var client = new PublishingPlatformClient(
+            books,
+            bookContent,
+            bookPublishing,
+            bookDistribution,
+            bookAccess,
+            bookAnalytics,
+            bookAuditLogs,
+            bookAssets,
+            webhooks);
+
+        client.Books.Should().BeSameAs(books);
+        client.BookContent.Should().BeSameAs(bookContent);
+        client.BookPublishing.Should().BeSameAs(bookPublishing);
+        client.BookDistribution.Should().BeSameAs(bookDistribution);
+        client.BookAccess.Should().BeSameAs(bookAccess);
+        client.BookAnalytics.Should().BeSameAs(bookAnalytics);
+        client.BookAuditLogs.Should().BeSameAs(bookAuditLogs);
+        client.BookAssets.Should().BeSameAs(bookAssets);
+        client.Webhooks.Should().BeSameAs(webhooks);
+    }
+
+    [Fact]
+    public void CreateFromTransport_ThrowsArgumentNullException_WhenTransportIsNull()
+    {
+        Action act = () => PublishingPlatformClient.CreateFromTransport(null!);
+
+        var exception = act.Should().Throw<ArgumentNullException>().Which;
+        exception.ParamName.Should().Be("transport");
+    }
+
+    [Fact]
+    public void CreateFromTransport_ReturnsClientWithAllModules_WhenTransportProvided()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+
+        var client = PublishingPlatformClient.CreateFromTransport(transport);
+
+        client.Should().NotBeNull();
+        client.Books.Should().NotBeNull();
+        client.BookContent.Should().NotBeNull();
+        client.BookPublishing.Should().NotBeNull();
+        client.BookDistribution.Should().NotBeNull();
+        client.BookAccess.Should().NotBeNull();
+        client.BookAnalytics.Should().NotBeNull();
+        client.BookAuditLogs.Should().NotBeNull();
+        client.BookAssets.Should().NotBeNull();
+        client.Webhooks.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
## Description

This PR improves SDK consumer guidance by expanding root client documentation and adding runnable initialization examples.

### What changed

- Expanded `README.md` with:
  - detailed initialization guidance (builder and DI styles),
  - module-access examples (`Books`, `BookContent`, `BookPublishing`, `Webhooks`),
  - thorough `IPublishingPlatformClient` property documentation,
  - use-case guidance per module and a quick module selection guide.
- Added new runnable examples in `examples/BasicUsage`:
  - `BuilderInitializationExample.csx`
  - `DiInitializationExample.csx`
- Updated `examples/BasicUsage/README.md` to list and explain available scripts.
- Updated local `rps-developer-skill` guidance to avoid redundant constructor null checks for DI-only dependencies.
- Aligned `PublishingPlatformClient` implementation and tests with the DI-constructor null-check rule.

### Why

- Make onboarding easier for SDK consumers by clarifying how to initialize and use the root client.
- Improve discoverability of module responsibilities and current SDK surface availability.
- Keep internal development guidance consistent with DI usage patterns.

### Testing

- `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal`
- Result: all tests passing.

### API impact

- No public API signature changes.
- Documentation and examples only for consumer-facing behavior.
- Internal validation behavior aligned with DI constructor policy.