### PR TITLE
RPS-69 fix: publish nuget bumps major instead of a patch version

### DIFF
--- a/.github/workflows/publish-nuget.yaml
+++ b/.github/workflows/publish-nuget.yaml
@@ -4,6 +4,12 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (example: v0.0.4)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -14,9 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NUGET_USER: ${{ secrets.NUGET_USER }}
+      TARGET_REF: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.event.release.tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ env.TARGET_REF }}
 
       - name: Set up .NET SDK
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4


### PR DESCRIPTION
# Validation

- [ ] `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal`
- [ ] Any additional checks relevant to this PR

# Release Please Override (Required for releasable changes)

This repository keeps PR/commit titles in `RPS-<id> type: subject` format.  
If this PR should trigger a Release Please release PR, add one override block below.

Use one of these prefixes in the override line:

- `feat: ...` (minor)
- `fix: ...` (patch)
- `feat!: ...` or `fix!: ...` (major/breaking)


BEGIN_COMMIT_OVERRIDE
fix: expand SDK initialization/module documentation and add runnable basic usage examples
END_COMMIT_OVERRIDE


If this PR is docs/chore/test-only and should not trigger a release, leave this section unchanged.
