### PR TITLE
RPS-50 feat: implement BookPublishing client operations and coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Runnable scripts are available in:
 
 - `examples/BasicUsage/BuilderInitializationExample.csx`
 - `examples/BasicUsage/DiInitializationExample.csx`
+- `examples/BookPublishing/BookPublishingExample.csx`
 
 ## Client modules: available properties and use cases
 
@@ -154,15 +155,18 @@ Typical use cases once expanded:
 
 Module accessor for publish-oriented workflows.
 
-Current status:
+Available operations:
 
-- Property is available on the root client.
-- Interface is currently a placeholder (no public operations yet in this SDK version).
+- `PublishAsync(...)`: publish a book and return current publishing state.
+- `UnpublishAsync(...)`: reverse publication and return current publishing state.
+- `ScheduleAsync(...)`: schedule publication at a specific date/time.
+- `GetStatusAsync(...)`: fetch the current publishing status for a book.
 
-Typical use cases once expanded:
+Typical use cases:
 
-- Triggering publication jobs.
-- Managing publish state transitions.
+- Triggering publication after metadata/content validation is complete.
+- Scheduling time-based release windows.
+- Operational checks for current publication state and failures.
 
 ### `BookDistribution` (`IBookDistributionClient`)
 

--- a/examples/BookPublishing/BookPublishingExample.csx
+++ b/examples/BookPublishing/BookPublishingExample.csx
@@ -1,0 +1,40 @@
+//r "nuget: PublishingPlatform.SDK"
+
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Options;
+
+var client = PublishingPlatformClientBuilder.Create(new PublishingPlatformClientOptions
+{
+    BaseUrl = "https://api.books.example",
+    ApiKey = "your-api-key",
+}).Build();
+
+var publishStatus = await client.BookPublishing.PublishAsync(
+    "book-123",
+    new PublishBookRequest
+    {
+        Notes = "Publishing after final editorial review.",
+    },
+    idempotencyKey: "publish-book-123-1");
+
+Console.WriteLine($"Publish status: {publishStatus.Status}");
+
+var scheduleStatus = await client.BookPublishing.ScheduleAsync(
+    "book-123",
+    new ScheduleBookPublishingRequest
+    {
+        ScheduledAt = DateTimeOffset.UtcNow.AddDays(2),
+    },
+    idempotencyKey: "schedule-book-123-1");
+
+Console.WriteLine($"Scheduled at: {scheduleStatus.ScheduledAt:O}");
+
+var currentStatus = await client.BookPublishing.GetStatusAsync("book-123");
+Console.WriteLine($"Current publishing state: {currentStatus.Status}");
+
+var unpublished = await client.BookPublishing.UnpublishAsync(
+    "book-123",
+    idempotencyKey: "unpublish-book-123-1");
+
+Console.WriteLine($"After unpublish: {unpublished.Status}");

--- a/examples/BookPublishing/README.md
+++ b/examples/BookPublishing/README.md
@@ -1,0 +1,12 @@
+# BookPublishing Example
+
+This example demonstrates publishing lifecycle operations through `IBookPublishingClient`:
+
+- `PublishAsync(...)`
+- `ScheduleAsync(...)`
+- `GetStatusAsync(...)`
+- `UnpublishAsync(...)`
+
+Run:
+
+- `examples/BookPublishing/BookPublishingExample.csx`

--- a/src/PublishingPlatform.SDK/Abstractions/IBookPublishingClient.cs
+++ b/src/PublishingPlatform.SDK/Abstractions/IBookPublishingClient.cs
@@ -1,5 +1,46 @@
-﻿namespace PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Models;
 
+namespace PublishingPlatform.SDK.Abstractions;
+
+/// <summary>
+/// Provides operations for publishing lifecycle state transitions of a book.
+/// </summary>
 public interface IBookPublishingClient
 {
+    /// <summary>
+    /// Publishes a book and returns its current publishing status.
+    /// </summary>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="request">The publish request payload.</param>
+    /// <param name="idempotencyKey">An optional idempotency key for safe retries.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The resulting <see cref="BookPublishingStatus"/>.</returns>
+    Task<BookPublishingStatus> PublishAsync(string bookId, PublishBookRequest request, string? idempotencyKey = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Unpublishes a book and returns its current publishing status.
+    /// </summary>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="idempotencyKey">An optional idempotency key for safe retries.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The resulting <see cref="BookPublishingStatus"/>.</returns>
+    Task<BookPublishingStatus> UnpublishAsync(string bookId, string? idempotencyKey = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Schedules a book to be published at a specified time and returns its current publishing status.
+    /// </summary>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="request">The schedule request payload.</param>
+    /// <param name="idempotencyKey">An optional idempotency key for safe retries.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The resulting <see cref="BookPublishingStatus"/>.</returns>
+    Task<BookPublishingStatus> ScheduleAsync(string bookId, ScheduleBookPublishingRequest request, string? idempotencyKey = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the current publishing status for a book.
+    /// </summary>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The current <see cref="BookPublishingStatus"/>.</returns>
+    Task<BookPublishingStatus> GetStatusAsync(string bookId, CancellationToken ct = default);
 }

--- a/src/PublishingPlatform.SDK/Clients/BookPublishing/Requests/DefaultBookPublishingRequestHeadersFactory.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookPublishing/Requests/DefaultBookPublishingRequestHeadersFactory.cs
@@ -1,0 +1,21 @@
+namespace PublishingPlatform.SDK.Clients.BookPublishing.Requests;
+
+/// <summary>
+/// Produces header sets for book publishing requests.
+/// </summary>
+internal sealed class DefaultBookPublishingRequestHeadersFactory : IBookPublishingRequestHeadersFactory
+{
+    /// <inheritdoc />
+    public IReadOnlyDictionary<string, string>? CreateIdempotencyHeaders(string? idempotencyKey)
+    {
+        if (string.IsNullOrWhiteSpace(idempotencyKey))
+        {
+            return null;
+        }
+
+        return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Idempotency-Key"] = idempotencyKey,
+        };
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/BookPublishing/Requests/IBookPublishingRequestHeadersFactory.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookPublishing/Requests/IBookPublishingRequestHeadersFactory.cs
@@ -1,0 +1,14 @@
+namespace PublishingPlatform.SDK.Clients.BookPublishing.Requests;
+
+/// <summary>
+/// Creates request headers for book publishing transport calls.
+/// </summary>
+internal interface IBookPublishingRequestHeadersFactory
+{
+    /// <summary>
+    /// Creates idempotency headers when an idempotency key is provided.
+    /// </summary>
+    /// <param name="idempotencyKey">The optional idempotency key.</param>
+    /// <returns>A headers dictionary, or <see langword="null"/> when no headers are needed.</returns>
+    IReadOnlyDictionary<string, string>? CreateIdempotencyHeaders(string? idempotencyKey);
+}

--- a/src/PublishingPlatform.SDK/Clients/BookPublishing/Serialization/DefaultBookPublishingResponseReader.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookPublishing/Serialization/DefaultBookPublishingResponseReader.cs
@@ -1,0 +1,23 @@
+using System.Net.Http.Json;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookPublishing.Serialization;
+
+/// <summary>
+/// Parses book publishing status responses and enforces non-empty payloads.
+/// </summary>
+internal sealed class DefaultBookPublishingResponseReader : IBookPublishingResponseReader
+{
+    /// <inheritdoc />
+    public async Task<BookPublishingStatus> ReadStatusAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        var status = await response.Content.ReadFromJsonAsync<BookPublishingStatus>(ct).ConfigureAwait(false);
+        if (status is null)
+        {
+            throw new BookValidationException("Book publishing status payload was empty.");
+        }
+
+        return status;
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/BookPublishing/Serialization/IBookPublishingResponseReader.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookPublishing/Serialization/IBookPublishingResponseReader.cs
@@ -1,0 +1,17 @@
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookPublishing.Serialization;
+
+/// <summary>
+/// Reads and validates publishing response payloads.
+/// </summary>
+internal interface IBookPublishingResponseReader
+{
+    /// <summary>
+    /// Reads a publishing status payload from an HTTP response.
+    /// </summary>
+    /// <param name="response">The HTTP response.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The parsed <see cref="BookPublishingStatus"/>.</returns>
+    Task<BookPublishingStatus> ReadStatusAsync(HttpResponseMessage response, CancellationToken ct);
+}

--- a/src/PublishingPlatform.SDK/Clients/BookPublishing/Validation/DefaultBookPublishingRequestValidator.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookPublishing/Validation/DefaultBookPublishingRequestValidator.cs
@@ -1,0 +1,37 @@
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookPublishing.Validation;
+
+/// <summary>
+/// Enforces input validation rules for book publishing operations.
+/// </summary>
+internal sealed class DefaultBookPublishingRequestValidator : IBookPublishingRequestValidator
+{
+    /// <inheritdoc />
+    public void ValidateBookId(string bookId)
+    {
+        if (string.IsNullOrWhiteSpace(bookId))
+        {
+            throw new BookValidationException("Book id is required.");
+        }
+    }
+
+    /// <inheritdoc />
+    public void ValidatePublish(PublishBookRequest request)
+    {
+        if (request.Notes is not null && string.IsNullOrWhiteSpace(request.Notes))
+        {
+            throw new BookValidationException("Notes cannot be empty when provided.");
+        }
+    }
+
+    /// <inheritdoc />
+    public void ValidateSchedule(ScheduleBookPublishingRequest request)
+    {
+        if (request.ScheduledAt == default)
+        {
+            throw new BookValidationException("ScheduledAt is required.");
+        }
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/BookPublishing/Validation/IBookPublishingRequestValidator.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookPublishing/Validation/IBookPublishingRequestValidator.cs
@@ -1,0 +1,27 @@
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookPublishing.Validation;
+
+/// <summary>
+/// Validates book publishing request inputs before transport execution.
+/// </summary>
+internal interface IBookPublishingRequestValidator
+{
+    /// <summary>
+    /// Validates the book identifier.
+    /// </summary>
+    /// <param name="bookId">The book identifier value.</param>
+    void ValidateBookId(string bookId);
+
+    /// <summary>
+    /// Validates a publish request payload.
+    /// </summary>
+    /// <param name="request">The publish request payload.</param>
+    void ValidatePublish(PublishBookRequest request);
+
+    /// <summary>
+    /// Validates a schedule publishing request payload.
+    /// </summary>
+    /// <param name="request">The schedule request payload.</param>
+    void ValidateSchedule(ScheduleBookPublishingRequest request);
+}

--- a/src/PublishingPlatform.SDK/Clients/BookPublishingClient.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookPublishingClient.cs
@@ -1,14 +1,128 @@
+using System.Diagnostics;
+using System.Net.Http.Json;
 using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Clients.BookPublishing.Requests;
+using PublishingPlatform.SDK.Clients.BookPublishing.Serialization;
+using PublishingPlatform.SDK.Clients.BookPublishing.Validation;
+using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Transport;
+using PublishingPlatform.SDK.Internal;
+using PublishingPlatform.SDK.Models;
 
 namespace PublishingPlatform.SDK.Clients;
 
+/// <summary>
+/// Implements book publishing lifecycle operations using the shared SDK transport.
+/// </summary>
 public sealed class BookPublishingClient : IBookPublishingClient
 {
     private readonly ISharedHttpTransport _transport;
+    private readonly IBookPublishingRequestValidator _validator;
+    private readonly IBookPublishingRequestHeadersFactory _requestHeadersFactory;
+    private readonly IBookPublishingResponseReader _responseReader;
 
     internal BookPublishingClient(ISharedHttpTransport transport)
+        : this(
+            transport,
+            new DefaultBookPublishingRequestValidator(),
+            new DefaultBookPublishingRequestHeadersFactory(),
+            new DefaultBookPublishingResponseReader())
+    {
+    }
+
+    internal BookPublishingClient(
+        ISharedHttpTransport transport,
+        IBookPublishingRequestValidator validator,
+        IBookPublishingRequestHeadersFactory requestHeadersFactory,
+        IBookPublishingResponseReader responseReader)
     {
         _transport = transport;
+        _validator = validator;
+        _requestHeadersFactory = requestHeadersFactory;
+        _responseReader = responseReader;
+    }
+
+    /// <inheritdoc />
+    public async Task<BookPublishingStatus> PublishAsync(string bookId, PublishBookRequest request, string? idempotencyKey = null, CancellationToken ct = default)
+    {
+        _validator.ValidateBookId(bookId);
+        Guards.NotNull(request, nameof(request));
+        _validator.ValidatePublish(request);
+
+        using var activity = StartActivity("BookPublishing.Publish");
+        var headers = _requestHeadersFactory.CreateIdempotencyHeaders(idempotencyKey);
+        var content = JsonContent.Create(request);
+        using var response = await _transport.SendAsync(
+            HttpMethod.Post,
+            $"/books/{Uri.EscapeDataString(bookId)}/publishing/publish",
+            content,
+            headers,
+            "BookPublishing.Publish",
+            ct).ConfigureAwait(false);
+
+        return await _responseReader.ReadStatusAsync(response, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<BookPublishingStatus> UnpublishAsync(string bookId, string? idempotencyKey = null, CancellationToken ct = default)
+    {
+        _validator.ValidateBookId(bookId);
+
+        using var activity = StartActivity("BookPublishing.Unpublish");
+        var headers = _requestHeadersFactory.CreateIdempotencyHeaders(idempotencyKey);
+        using var response = await _transport.SendAsync(
+            HttpMethod.Post,
+            $"/books/{Uri.EscapeDataString(bookId)}/publishing/unpublish",
+            null,
+            headers,
+            "BookPublishing.Unpublish",
+            ct).ConfigureAwait(false);
+
+        return await _responseReader.ReadStatusAsync(response, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<BookPublishingStatus> ScheduleAsync(string bookId, ScheduleBookPublishingRequest request, string? idempotencyKey = null, CancellationToken ct = default)
+    {
+        _validator.ValidateBookId(bookId);
+        Guards.NotNull(request, nameof(request));
+        _validator.ValidateSchedule(request);
+
+        using var activity = StartActivity("BookPublishing.Schedule");
+        var headers = _requestHeadersFactory.CreateIdempotencyHeaders(idempotencyKey);
+        var content = JsonContent.Create(request);
+        using var response = await _transport.SendAsync(
+            HttpMethod.Post,
+            $"/books/{Uri.EscapeDataString(bookId)}/publishing/schedule",
+            content,
+            headers,
+            "BookPublishing.Schedule",
+            ct).ConfigureAwait(false);
+
+        return await _responseReader.ReadStatusAsync(response, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<BookPublishingStatus> GetStatusAsync(string bookId, CancellationToken ct = default)
+    {
+        _validator.ValidateBookId(bookId);
+
+        using var activity = StartActivity("BookPublishing.GetStatus");
+        using var response = await _transport.SendAsync(
+            HttpMethod.Get,
+            $"/books/{Uri.EscapeDataString(bookId)}/publishing/status",
+            null,
+            null,
+            "BookPublishing.GetStatus",
+            ct).ConfigureAwait(false);
+
+        return await _responseReader.ReadStatusAsync(response, ct).ConfigureAwait(false);
+    }
+
+    private static Activity? StartActivity(string operationName)
+    {
+        var activity = ActivitySourceProvider.ActivitySource.StartActivity(operationName, ActivityKind.Client);
+        activity?.SetTag("sdk.operation", operationName);
+        return activity;
     }
 }

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/Requests/DefaultTransportRequestFactory.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/Requests/DefaultTransportRequestFactory.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Headers;
+using PublishingPlatform.SDK.Infrastructure.Transport;
 
 namespace PublishingPlatform.SDK.Infrastructure.Transport.Requests;
 
@@ -16,9 +17,9 @@ internal sealed class DefaultTransportRequestFactory : ITransportRequestFactory
             Content = content,
         };
 
-        if (!request.Headers.Contains(SharedHttpTransport.CorrelationHeaderName))
+        if (!request.Headers.Contains(TransportHeaderNames.CorrelationId))
         {
-            request.Headers.Add(SharedHttpTransport.CorrelationHeaderName, correlationId);
+            request.Headers.Add(TransportHeaderNames.CorrelationId, correlationId);
         }
 
         if (headers is not null)

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransport.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransport.cs
@@ -6,7 +6,7 @@ namespace PublishingPlatform.SDK.Infrastructure.Transport;
 
 internal sealed class SharedHttpTransport : ISharedHttpTransport
 {
-    internal const string CorrelationHeaderName = "X-Correlation-Id";
+    internal const string CorrelationHeaderName = TransportHeaderNames.CorrelationId;
 
     private readonly HttpClient _httpClient;
     private readonly IPublishingPlatformResiliencePipeline _resiliencePipeline;
@@ -21,14 +21,24 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
         IPublishingPlatformResiliencePipeline resiliencePipeline,
         ICorrelationIdProvider correlationIdProvider,
         IPublishingPlatformErrorMapper errorMapper)
+        : this(httpClient, resiliencePipeline, correlationIdProvider, errorMapper, TransportDependencies.CreateDefault())
+    {
+    }
+
+    private SharedHttpTransport(
+        HttpClient httpClient,
+        IPublishingPlatformResiliencePipeline resiliencePipeline,
+        ICorrelationIdProvider correlationIdProvider,
+        IPublishingPlatformErrorMapper errorMapper,
+        TransportDependencies dependencies)
         : this(
             httpClient,
             resiliencePipeline,
             correlationIdProvider,
             errorMapper,
-            TransportDependencies.CreateDefault().RequestFactory,
-            TransportDependencies.CreateDefault().ResponseErrorReader,
-            TransportDependencies.CreateDefault().ErrorContextFactory)
+            dependencies.RequestFactory,
+            dependencies.ResponseErrorReader,
+            dependencies.ErrorContextFactory)
     {
     }
 

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/TransportHeaderNames.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/TransportHeaderNames.cs
@@ -1,0 +1,12 @@
+namespace PublishingPlatform.SDK.Infrastructure.Transport;
+
+/// <summary>
+/// Defines canonical transport-level HTTP header names used by SDK internals.
+/// </summary>
+internal static class TransportHeaderNames
+{
+    /// <summary>
+    /// Correlation header used to propagate request tracing context.
+    /// </summary>
+    internal const string CorrelationId = "X-Correlation-Id";
+}

--- a/src/PublishingPlatform.SDK/Models/BookPublishingStatus.cs
+++ b/src/PublishingPlatform.SDK/Models/BookPublishingStatus.cs
@@ -1,0 +1,32 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents publishing state for a specific book.
+/// </summary>
+public sealed class BookPublishingStatus
+{
+    /// <summary>
+    /// Gets or sets the book identifier.
+    /// </summary>
+    public string BookId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the publishing status value.
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the scheduled publish date-time, if present.
+    /// </summary>
+    public DateTimeOffset? ScheduledAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the completed publish date-time, if present.
+    /// </summary>
+    public DateTimeOffset? PublishedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional failure reason.
+    /// </summary>
+    public string? FailureReason { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Models/PublishBookRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/PublishBookRequest.cs
@@ -1,0 +1,12 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents a publish request payload for a book.
+/// </summary>
+public sealed class PublishBookRequest
+{
+    /// <summary>
+    /// Gets or sets optional publishing notes.
+    /// </summary>
+    public string? Notes { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Models/ScheduleBookPublishingRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/ScheduleBookPublishingRequest.cs
@@ -1,0 +1,12 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents a request to schedule book publishing.
+/// </summary>
+public sealed class ScheduleBookPublishingRequest
+{
+    /// <summary>
+    /// Gets or sets the date-time when publishing should occur.
+    /// </summary>
+    public DateTimeOffset ScheduledAt { get; set; }
+}

--- a/tests/PublishingPlatform.SDK.Tests/BookPublishing/BookPublishingClientTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/BookPublishing/BookPublishingClientTests.cs
@@ -1,0 +1,200 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Infrastructure.Errors;
+using PublishingPlatform.SDK.Infrastructure.Transport;
+using PublishingPlatform.SDK.Internal.Resilience;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Tests.BookPublishing;
+
+public sealed class BookPublishingClientTests
+{
+    [Fact]
+    public async Task PublishAsync_SendsPostToExpectedPath_WithIdempotencyHeader()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+                HttpMethod.Post,
+                "/books/book-1/publishing/publish",
+                Arg.Any<HttpContent>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                "BookPublishing.Publish",
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new BookPublishingStatus { BookId = "book-1", Status = "published" }),
+            }));
+
+        var sut = new BookPublishingClient(transport);
+
+        var result = await sut.PublishAsync("book-1", new PublishBookRequest { Notes = "Ship it." }, "idem-publish");
+
+        result.Status.Should().Be("published");
+        await transport.Received(1).SendAsync(
+            HttpMethod.Post,
+            "/books/book-1/publishing/publish",
+            Arg.Any<HttpContent>(),
+            Arg.Is<IReadOnlyDictionary<string, string>>(h => h["Idempotency-Key"] == "idem-publish"),
+            "BookPublishing.Publish",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UnpublishAsync_SendsPostToExpectedPath()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+                HttpMethod.Post,
+                "/books/book-2/publishing/unpublish",
+                null,
+                null,
+                "BookPublishing.Unpublish",
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new BookPublishingStatus { BookId = "book-2", Status = "unpublished" }),
+            }));
+
+        var sut = new BookPublishingClient(transport);
+
+        var result = await sut.UnpublishAsync("book-2");
+
+        result.Status.Should().Be("unpublished");
+        await transport.Received(1).SendAsync(
+            HttpMethod.Post,
+            "/books/book-2/publishing/unpublish",
+            null,
+            null,
+            "BookPublishing.Unpublish",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ScheduleAsync_SendsPostToExpectedPath_WithPayload()
+    {
+        var scheduledAt = DateTimeOffset.Parse("2026-06-01T10:00:00Z");
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+                HttpMethod.Post,
+                "/books/book-3/publishing/schedule",
+                Arg.Any<HttpContent>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                "BookPublishing.Schedule",
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new BookPublishingStatus { BookId = "book-3", Status = "scheduled", ScheduledAt = scheduledAt }),
+            }));
+
+        var sut = new BookPublishingClient(transport);
+
+        var result = await sut.ScheduleAsync("book-3", new ScheduleBookPublishingRequest { ScheduledAt = scheduledAt }, "idem-schedule");
+
+        result.Status.Should().Be("scheduled");
+        result.ScheduledAt.Should().Be(scheduledAt);
+        await transport.Received(1).SendAsync(
+            HttpMethod.Post,
+            "/books/book-3/publishing/schedule",
+            Arg.Any<HttpContent>(),
+            Arg.Is<IReadOnlyDictionary<string, string>>(h => h["Idempotency-Key"] == "idem-schedule"),
+            "BookPublishing.Schedule",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_SendsGetToExpectedPath()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+                HttpMethod.Get,
+                "/books/book-4/publishing/status",
+                null,
+                null,
+                "BookPublishing.GetStatus",
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new BookPublishingStatus { BookId = "book-4", Status = "published" }),
+            }));
+
+        var sut = new BookPublishingClient(transport);
+
+        var result = await sut.GetStatusAsync("book-4");
+
+        result.BookId.Should().Be("book-4");
+        await transport.Received(1).SendAsync(
+            HttpMethod.Get,
+            "/books/book-4/publishing/status",
+            null,
+            null,
+            "BookPublishing.GetStatus",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task PublishAsync_ThrowsBookValidationException_ForInvalidBookId(string bookId)
+    {
+        var sut = new BookPublishingClient(Substitute.For<ISharedHttpTransport>());
+
+        var act = async () => await sut.PublishAsync(bookId, new PublishBookRequest());
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Book id is required");
+    }
+
+    [Fact]
+    public async Task ScheduleAsync_ThrowsBookValidationException_ForMissingScheduledAt()
+    {
+        var sut = new BookPublishingClient(Substitute.For<ISharedHttpTransport>());
+
+        var act = async () => await sut.ScheduleAsync("book-5", new ScheduleBookPublishingRequest());
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("ScheduledAt is required");
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_ThrowsBookValidationException_WhenResponsePayloadIsNull()
+    {
+        using var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, "application/json"),
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.test") };
+        var transport = new SharedHttpTransport(client, new NoOpPublishingPlatformResiliencePipeline(), new FixedCorrelationIdProvider(), new DefaultPublishingPlatformErrorMapper());
+        var sut = new BookPublishingClient(transport);
+
+        var act = async () => await sut.GetStatusAsync("book-null");
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Book publishing status payload was empty");
+    }
+
+    private sealed class SingleResponseHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+
+        public SingleResponseHandler(HttpResponseMessage response)
+        {
+            _response = response;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_response);
+        }
+    }
+
+    private sealed class FixedCorrelationIdProvider : ICorrelationIdProvider
+    {
+        public string Create()
+        {
+            return Guid.NewGuid().ToString("N");
+        }
+    }
+}

--- a/tests/PublishingPlatform.SDK.Tests/BookPublishing/BookPublishingCollaboratorsTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/BookPublishing/BookPublishingCollaboratorsTests.cs
@@ -1,0 +1,75 @@
+using System.Text;
+using Bogus;
+using PublishingPlatform.SDK.Clients.BookPublishing.Requests;
+using PublishingPlatform.SDK.Clients.BookPublishing.Serialization;
+using PublishingPlatform.SDK.Clients.BookPublishing.Validation;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Tests.BookPublishing;
+
+public sealed class BookPublishingCollaboratorsTests
+{
+    [Fact]
+    public void Validator_RejectsWhitespaceNotes_WhenProvided()
+    {
+        var validator = new DefaultBookPublishingRequestValidator();
+        var request = new PublishBookRequest
+        {
+            Notes = "   ",
+        };
+
+        Action act = () => validator.ValidatePublish(request);
+
+        act.Should().Throw<BookValidationException>()
+            .WithMessage("*Notes cannot be empty*");
+    }
+
+    [Fact]
+    public void Validator_RejectsDefaultScheduleDate()
+    {
+        var validator = new DefaultBookPublishingRequestValidator();
+
+        Action act = () => validator.ValidateSchedule(new ScheduleBookPublishingRequest());
+
+        act.Should().Throw<BookValidationException>()
+            .WithMessage("*ScheduledAt is required*");
+    }
+
+    [Fact]
+    public void HeadersFactory_ReturnsNull_WhenIdempotencyKeyMissing()
+    {
+        var factory = new DefaultBookPublishingRequestHeadersFactory();
+
+        var headers = factory.CreateIdempotencyHeaders(null);
+
+        headers.Should().BeNull();
+    }
+
+    [Fact]
+    public void HeadersFactory_EmitsIdempotencyHeader_WhenKeyProvided()
+    {
+        var factory = new DefaultBookPublishingRequestHeadersFactory();
+        var idempotencyKey = new Faker().Random.Guid().ToString("N");
+
+        var headers = factory.CreateIdempotencyHeaders(idempotencyKey);
+
+        headers.Should().NotBeNull();
+        headers!["Idempotency-Key"].Should().Be(idempotencyKey);
+    }
+
+    [Fact]
+    public async Task ResponseReader_Throws_WhenPayloadIsNull()
+    {
+        var reader = new DefaultBookPublishingResponseReader();
+        using var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, "application/json"),
+        };
+
+        Func<Task> act = async () => await reader.ReadStatusAsync(response, CancellationToken.None);
+
+        _ = await act.Should().ThrowAsync<BookValidationException>()
+            .WithMessage("*payload was empty*");
+    }
+}


### PR DESCRIPTION
## Title
RPS-50 feat: implement BookPublishing client operations and coverage

## Summary
Implements the `IBookPublishingClient` contract with concrete publish lifecycle operations, adds supporting models/collaborators, expands documentation, and adds both orchestration and collaborator seam tests.

## What Changed
- Implemented `IBookPublishingClient` operations:
  - `PublishAsync`
  - `UnpublishAsync`
  - `ScheduleAsync`
  - `GetStatusAsync`
- Added publishing models:
  - `PublishBookRequest`
  - `ScheduleBookPublishingRequest`
  - `BookPublishingStatus`
- Added internal collaborators for layered client architecture:
  - validator (`DefaultBookPublishingRequestValidator`)
  - headers factory (`DefaultBookPublishingRequestHeadersFactory`)
  - response reader (`DefaultBookPublishingResponseReader`)
- Added/updated XML documentation for interface, client, and internal collaborators.
- Updated `README.md` to document `BookPublishing` as implemented (not placeholder).
- Added runnable consumer example:
  - `examples/BookPublishing/BookPublishingExample.csx`
  - `examples/BookPublishing/README.md`
- Added tests:
  - `BookPublishingClientTests` for API-path/header/validation/empty-payload behavior
  - `BookPublishingCollaboratorsTests` for validator/header/reader seam coverage

## Testing
- `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal`
- Result: Passed (`110` passed, `0` failed, `0` skipped)

## API Impact
- Public API expanded:
  - `IBookPublishingClient` now exposes publish lifecycle operations.
- New public models introduced:
  - `PublishBookRequest`
  - `ScheduleBookPublishingRequest`
  - `BookPublishingStatus`
- No breaking changes were introduced to existing method signatures.

## Release Please Override

BEGIN_COMMIT_OVERRIDE
feat: implement BookPublishing client operations with models, docs, and tests
END_COMMIT_OVERRIDE