### PR TITLE
RPS-17 docs: Add strongly typed request models for the upcoming `BookAccess`, `BookAnalytics`, `BookAuditLogs`, `BookAssets`, and `Webhooks` module operations, and expand internal Google Books contract payloads with explicit static manual mapping helpers.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.8</Version>
+    <Version>0.0.9</Version>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Current status:
 
 - Property is available on the root client.
 - Interface is currently a placeholder (no public operations yet in this SDK version).
+- Strongly typed request models are available for upcoming access operations (`BookAccessGrantRequest`, `BookAccessRevokeRequest`).
 
 Typical use cases once expanded:
 
@@ -176,6 +177,7 @@ Current status:
 
 - Property is available on the root client.
 - Interface is currently a placeholder (no public operations yet in this SDK version).
+- Strongly typed request models are available for upcoming analytics queries (`GetBookAnalyticsRequest`).
 
 Typical use cases once expanded:
 
@@ -190,6 +192,7 @@ Current status:
 
 - Property is available on the root client.
 - Interface is currently a placeholder (no public operations yet in this SDK version).
+- Strongly typed request models are available for upcoming audit log queries (`ListBookAuditLogsRequest`).
 
 Typical use cases once expanded:
 
@@ -204,6 +207,7 @@ Current status:
 
 - Property is available on the root client.
 - Interface is currently a placeholder (no public operations yet in this SDK version).
+- Strongly typed request models are available for upcoming asset operations (`UploadBookAssetRequest`, `DeleteBookAssetRequest`).
 
 Typical use cases once expanded:
 
@@ -218,6 +222,7 @@ Current status:
 
 - Property is available on the root client.
 - Interface is currently a placeholder (no public operations yet in this SDK version).
+- Strongly typed request models are available for upcoming webhook registration and management (`RegisterWebhookRequest`, `UpdateWebhookRequest`).
 
 Typical use cases once expanded:
 

--- a/docs/pr-completion.md
+++ b/docs/pr-completion.md
@@ -1,0 +1,49 @@
+# Summary
+
+Add strongly typed request models for the upcoming `BookAccess`, `BookAnalytics`, `BookAuditLogs`, `BookAssets`, and `Webhooks` module operations, and expand internal Google Books contract payloads with explicit static manual mapping helpers.
+
+What changed:
+- Added new public request models:
+  - `BookAccessGrantRequest`, `BookAccessRevokeRequest`
+  - `GetBookAnalyticsRequest`
+  - `ListBookAuditLogsRequest`
+  - `UploadBookAssetRequest`, `DeleteBookAssetRequest`
+  - `RegisterWebhookRequest`, `UpdateWebhookRequest`
+- Expanded internal Google Books wire contracts with broader payload shapes:
+  - `GoogleBooksVolumesResponsePayload`
+  - `GoogleBooksImageLinksPayload`
+  - `GoogleBooksIndustryIdentifierPayload`
+  - extended `GoogleBooksVolumeInfoPayload` fields
+- Extended static manual mapping with collection mapping (`ToBooks`) and category-to-tag propagation, while keeping provider models internal.
+- Updated architecture boundary and contract tests for the new internal payloads and mapping behavior.
+- Updated README module status sections to document available strongly typed request models for upcoming operations.
+
+API impact:
+- Public SDK model surface expanded with new `*Request` types.
+- No new public client methods were introduced in this ticket.
+- Google Books provider contracts remain internal and non-leaking.
+
+# Validation
+
+- [x] `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal`
+- [x] Added/updated tests for request model defaults, Google mapping behavior, and internal visibility boundaries
+
+Test result evidence:
+- Passed: 128
+- Failed: 0
+- Skipped: 0
+
+# Release Please Override (Required for releasable changes)
+
+```text
+BEGIN_COMMIT_OVERRIDE
+feat: add strongly typed request models and expand internal google books mappings
+END_COMMIT_OVERRIDE
+```
+
+# Manual NuGet Publish
+
+1. Confirm `Directory.Build.props` version equals the intended release version.
+2. Create matching tag `v<version>` on the exact commit to publish.
+3. Run the `Publish NuGet` workflow manually with the same tag.
+4. Verify the published package version appears on NuGet.

--- a/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/GoogleBooksImageLinksPayload.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/GoogleBooksImageLinksPayload.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace PublishingPlatform.SDK.Infrastructure.GoogleBooks;
+
+/// <summary>
+/// Represents image link metadata from Google Books.
+/// </summary>
+internal sealed class GoogleBooksImageLinksPayload
+{
+    /// <summary>
+    /// Gets or sets the small thumbnail URL.
+    /// </summary>
+    [JsonPropertyName("smallThumbnail")]
+    public string? SmallThumbnail { get; set; }
+
+    /// <summary>
+    /// Gets or sets the thumbnail URL.
+    /// </summary>
+    [JsonPropertyName("thumbnail")]
+    public string? Thumbnail { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/GoogleBooksIndustryIdentifierPayload.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/GoogleBooksIndustryIdentifierPayload.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace PublishingPlatform.SDK.Infrastructure.GoogleBooks;
+
+/// <summary>
+/// Represents industry identifier metadata from Google Books.
+/// </summary>
+internal sealed class GoogleBooksIndustryIdentifierPayload
+{
+    /// <summary>
+    /// Gets or sets the identifier type.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier value.
+    /// </summary>
+    [JsonPropertyName("identifier")]
+    public string? Identifier { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/GoogleBooksMappingExtensions.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/GoogleBooksMappingExtensions.cs
@@ -21,6 +21,30 @@ internal static class GoogleBooksMappingExtensions
             Author = payload.VolumeInfo?.Authors is { Count: > 0 } authors
                 ? authors[0]
                 : string.Empty,
+            Tags = payload.VolumeInfo?.Categories is { Count: > 0 } categories
+                ? categories
+                : Array.Empty<string>(),
         };
+    }
+
+    /// <summary>
+    /// Maps a Google Books volumes response into platform <see cref="Book"/> models.
+    /// </summary>
+    /// <param name="payload">The source payload.</param>
+    /// <returns>Mapped books.</returns>
+    public static IReadOnlyList<Book> ToBooks(this GoogleBooksVolumesResponsePayload payload)
+    {
+        if (payload.Items is null || payload.Items.Count == 0)
+        {
+            return Array.Empty<Book>();
+        }
+
+        var books = new Book[payload.Items.Count];
+        for (var i = 0; i < payload.Items.Count; i++)
+        {
+            books[i] = payload.Items[i].ToBook();
+        }
+
+        return books;
     }
 }

--- a/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/GoogleBooksVolumeInfoPayload.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/GoogleBooksVolumeInfoPayload.cs
@@ -14,8 +14,56 @@ internal sealed class GoogleBooksVolumeInfoPayload
     public string? Title { get; set; }
 
     /// <summary>
+    /// Gets or sets the subtitle.
+    /// </summary>
+    [JsonPropertyName("subtitle")]
+    public string? Subtitle { get; set; }
+
+    /// <summary>
     /// Gets or sets author names.
     /// </summary>
     [JsonPropertyName("authors")]
     public IReadOnlyList<string>? Authors { get; set; }
+
+    /// <summary>
+    /// Gets or sets category names.
+    /// </summary>
+    [JsonPropertyName("categories")]
+    public IReadOnlyList<string>? Categories { get; set; }
+
+    /// <summary>
+    /// Gets or sets the description.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the published date.
+    /// </summary>
+    [JsonPropertyName("publishedDate")]
+    public string? PublishedDate { get; set; }
+
+    /// <summary>
+    /// Gets or sets page count.
+    /// </summary>
+    [JsonPropertyName("pageCount")]
+    public int? PageCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets language code.
+    /// </summary>
+    [JsonPropertyName("language")]
+    public string? Language { get; set; }
+
+    /// <summary>
+    /// Gets or sets image links.
+    /// </summary>
+    [JsonPropertyName("imageLinks")]
+    public GoogleBooksImageLinksPayload? ImageLinks { get; set; }
+
+    /// <summary>
+    /// Gets or sets industry identifiers.
+    /// </summary>
+    [JsonPropertyName("industryIdentifiers")]
+    public IReadOnlyList<GoogleBooksIndustryIdentifierPayload>? IndustryIdentifiers { get; set; }
 }

--- a/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/GoogleBooksVolumesResponsePayload.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/GoogleBooks/GoogleBooksVolumesResponsePayload.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace PublishingPlatform.SDK.Infrastructure.GoogleBooks;
+
+/// <summary>
+/// Represents the Google Books volumes API response payload.
+/// </summary>
+internal sealed class GoogleBooksVolumesResponsePayload
+{
+    /// <summary>
+    /// Gets or sets the response kind.
+    /// </summary>
+    [JsonPropertyName("kind")]
+    public string? Kind { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total number of matches.
+    /// </summary>
+    [JsonPropertyName("totalItems")]
+    public int TotalItems { get; set; }
+
+    /// <summary>
+    /// Gets or sets the returned volume items.
+    /// </summary>
+    [JsonPropertyName("items")]
+    public IReadOnlyList<GoogleBooksVolumePayload>? Items { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Models/BookAccessGrantRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/BookAccessGrantRequest.cs
@@ -1,0 +1,32 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents a request to grant access to a book principal.
+/// </summary>
+public sealed class BookAccessGrantRequest
+{
+    /// <summary>
+    /// Gets or sets the book identifier.
+    /// </summary>
+    public string BookId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the principal identifier receiving access.
+    /// </summary>
+    public string PrincipalId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the access level to grant.
+    /// </summary>
+    public string AccessLevel { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the optional expiration date for the grant.
+    /// </summary>
+    public DateTimeOffset? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional idempotency key for retry-safe grant requests.
+    /// </summary>
+    public string? IdempotencyKey { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Models/BookAccessRevokeRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/BookAccessRevokeRequest.cs
@@ -1,0 +1,22 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents a request to revoke access from a book principal.
+/// </summary>
+public sealed class BookAccessRevokeRequest
+{
+    /// <summary>
+    /// Gets or sets the book identifier.
+    /// </summary>
+    public string BookId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the principal identifier losing access.
+    /// </summary>
+    public string PrincipalId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets an optional reason for auditability.
+    /// </summary>
+    public string? Reason { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Models/DeleteBookAssetRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/DeleteBookAssetRequest.cs
@@ -1,0 +1,22 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents a request to delete an existing book asset.
+/// </summary>
+public sealed class DeleteBookAssetRequest
+{
+    /// <summary>
+    /// Gets or sets the book identifier.
+    /// </summary>
+    public string BookId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the asset identifier.
+    /// </summary>
+    public string AssetId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets an optional reason for deletion.
+    /// </summary>
+    public string? Reason { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Models/GetBookAnalyticsRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/GetBookAnalyticsRequest.cs
@@ -1,0 +1,32 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents a request for book analytics aggregation data.
+/// </summary>
+public sealed class GetBookAnalyticsRequest
+{
+    /// <summary>
+    /// Gets or sets the book identifier.
+    /// </summary>
+    public string BookId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the inclusive range start.
+    /// </summary>
+    public DateTimeOffset? From { get; set; }
+
+    /// <summary>
+    /// Gets or sets the inclusive range end.
+    /// </summary>
+    public DateTimeOffset? To { get; set; }
+
+    /// <summary>
+    /// Gets or sets the aggregation granularity (for example, day/week/month).
+    /// </summary>
+    public string Granularity { get; set; } = "day";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether unique reader count is requested.
+    /// </summary>
+    public bool IncludeUniqueReaders { get; set; } = true;
+}

--- a/src/PublishingPlatform.SDK/Models/ListBookAuditLogsRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/ListBookAuditLogsRequest.cs
@@ -1,0 +1,47 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents filtering and paging criteria for book audit log queries.
+/// </summary>
+public sealed class ListBookAuditLogsRequest
+{
+    /// <summary>
+    /// Gets or sets the book identifier.
+    /// </summary>
+    public string BookId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets an optional actor identifier filter.
+    /// </summary>
+    public string? ActorId { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional action filter.
+    /// </summary>
+    public string? Action { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional inclusive range start.
+    /// </summary>
+    public DateTimeOffset? From { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional inclusive range end.
+    /// </summary>
+    public DateTimeOffset? To { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional correlation identifier filter.
+    /// </summary>
+    public string? CorrelationId { get; set; }
+
+    /// <summary>
+    /// Gets or sets zero-based page index.
+    /// </summary>
+    public int Page { get; set; }
+
+    /// <summary>
+    /// Gets or sets requested page size.
+    /// </summary>
+    public int PageSize { get; set; } = 50;
+}

--- a/src/PublishingPlatform.SDK/Models/RegisterWebhookRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/RegisterWebhookRequest.cs
@@ -1,0 +1,27 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents a request to register a webhook endpoint.
+/// </summary>
+public sealed class RegisterWebhookRequest
+{
+    /// <summary>
+    /// Gets or sets the callback endpoint URL.
+    /// </summary>
+    public string EndpointUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets subscribed event names.
+    /// </summary>
+    public IReadOnlyList<string> Events { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this webhook is active.
+    /// </summary>
+    public bool IsActive { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets an optional signing key identifier managed outside the SDK.
+    /// </summary>
+    public string? SigningKeyId { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Models/UpdateWebhookRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/UpdateWebhookRequest.cs
@@ -1,0 +1,27 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents a request to update webhook endpoint settings.
+/// </summary>
+public sealed class UpdateWebhookRequest
+{
+    /// <summary>
+    /// Gets or sets the webhook identifier.
+    /// </summary>
+    public string WebhookId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the callback endpoint URL.
+    /// </summary>
+    public string EndpointUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets subscribed event names.
+    /// </summary>
+    public IReadOnlyList<string> Events { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this webhook remains active.
+    /// </summary>
+    public bool IsActive { get; set; } = true;
+}

--- a/src/PublishingPlatform.SDK/Models/UploadBookAssetRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/UploadBookAssetRequest.cs
@@ -1,0 +1,32 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents a request to upload or replace a book asset.
+/// </summary>
+public sealed class UploadBookAssetRequest
+{
+    /// <summary>
+    /// Gets or sets the book identifier.
+    /// </summary>
+    public string BookId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the logical asset type (for example cover/preview).
+    /// </summary>
+    public string AssetType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the source file name.
+    /// </summary>
+    public string FileName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the content type of the uploaded asset.
+    /// </summary>
+    public string ContentType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets an optional idempotency key for retry-safe uploads.
+    /// </summary>
+    public string? IdempotencyKey { get; set; }
+}

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/ArchitectureBoundariesTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/ArchitectureBoundariesTests.cs
@@ -11,6 +11,9 @@ public sealed class ArchitectureBoundariesTests
     {
         typeof(GoogleBooksVolumePayload).IsPublic.Should().BeFalse();
         typeof(GoogleBooksVolumeInfoPayload).IsPublic.Should().BeFalse();
+        typeof(GoogleBooksVolumesResponsePayload).IsPublic.Should().BeFalse();
+        typeof(GoogleBooksImageLinksPayload).IsPublic.Should().BeFalse();
+        typeof(GoogleBooksIndustryIdentifierPayload).IsPublic.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/InfrastructureContractsTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/InfrastructureContractsTests.cs
@@ -5,6 +5,7 @@ using PublishingPlatform.SDK.Infrastructure.Http.Handlers;
 using PublishingPlatform.SDK.Infrastructure.Transport;
 using PublishingPlatform.SDK.Models;
 using PublishingPlatform.SDK.Models.Common;
+using System.Text.Json;
 
 namespace PublishingPlatform.SDK.Tests.Infrastructure;
 
@@ -97,6 +98,79 @@ public sealed class InfrastructureContractsTests
         mapped.Should().HaveCount(1);
         mapped[0].Id.Should().Be("gid-1");
         mapped[0].Tags.Should().Equal("tech", "architecture");
+    }
+
+    [Fact]
+    public void GoogleBooksMapping_ToBook_UsesSafeFallbacksWhenVolumeInfoMissing()
+    {
+        var payload = new GoogleBooksVolumePayload
+        {
+            Id = "gid-fallback",
+            VolumeInfo = null,
+        };
+
+        var mapped = payload.ToBook();
+
+        mapped.Id.Should().Be("gid-fallback");
+        mapped.Title.Should().BeEmpty();
+        mapped.Author.Should().BeEmpty();
+        mapped.Tags.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GoogleBooksMapping_ToBooks_ReturnsEmptyWhenItemsMissing()
+    {
+        var nullItemsPayload = new GoogleBooksVolumesResponsePayload { Items = null };
+        var emptyItemsPayload = new GoogleBooksVolumesResponsePayload { Items = [] };
+
+        nullItemsPayload.ToBooks().Should().BeEmpty();
+        emptyItemsPayload.ToBooks().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GoogleBooksPayloadContracts_DeserializeExpectedJsonFields()
+    {
+        const string json = """
+                            {
+                              "kind": "books#volumes",
+                              "totalItems": 1,
+                              "items": [
+                                {
+                                  "id": "vol-1",
+                                  "volumeInfo": {
+                                    "title": "Sample",
+                                    "subtitle": "Sub",
+                                    "authors": ["A1"],
+                                    "categories": ["cat1"],
+                                    "description": "Desc",
+                                    "publishedDate": "2025-01-01",
+                                    "pageCount": 120,
+                                    "language": "en",
+                                    "imageLinks": {
+                                      "smallThumbnail": "https://img/small.jpg",
+                                      "thumbnail": "https://img/thumb.jpg"
+                                    },
+                                    "industryIdentifiers": [
+                                      { "type": "ISBN_13", "identifier": "9780000000000" }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                            """;
+
+        var payload = JsonSerializer.Deserialize<GoogleBooksVolumesResponsePayload>(json);
+
+        payload.Should().NotBeNull();
+        payload!.Kind.Should().Be("books#volumes");
+        payload.TotalItems.Should().Be(1);
+        payload.Items.Should().HaveCount(1);
+        var first = payload.Items![0];
+        first.VolumeInfo.Should().NotBeNull();
+        first.VolumeInfo!.ImageLinks.Should().NotBeNull();
+        first.VolumeInfo.IndustryIdentifiers.Should().NotBeNull();
+        first.VolumeInfo.ImageLinks!.Thumbnail.Should().Be("https://img/thumb.jpg");
+        first.VolumeInfo.IndustryIdentifiers!.Single().Type.Should().Be("ISBN_13");
     }
 
     [Fact]

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/InfrastructureContractsTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/InfrastructureContractsTests.cs
@@ -73,6 +73,33 @@ public sealed class InfrastructureContractsTests
     }
 
     [Fact]
+    public void GoogleBooksMapping_ToBooks_MapsCollectionAndCategories()
+    {
+        var payload = new GoogleBooksVolumesResponsePayload
+        {
+            Items =
+            [
+                new GoogleBooksVolumePayload
+                {
+                    Id = "gid-1",
+                    VolumeInfo = new GoogleBooksVolumeInfoPayload
+                    {
+                        Title = "GTitle1",
+                        Authors = ["A1", "A2"],
+                        Categories = ["tech", "architecture"],
+                    },
+                },
+            ],
+        };
+
+        var mapped = payload.ToBooks();
+
+        mapped.Should().HaveCount(1);
+        mapped[0].Id.Should().Be("gid-1");
+        mapped[0].Tags.Should().Equal("tech", "architecture");
+    }
+
+    [Fact]
     public void DiagnosticsAndPaginationDefaults_AreStable()
     {
         var diagnostics = new DiagnosticsOptions();

--- a/tests/PublishingPlatform.SDK.Tests/Models/RequestModelContractsTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Models/RequestModelContractsTests.cs
@@ -1,0 +1,91 @@
+using Bogus;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Tests.ModelContracts;
+
+public sealed class RequestModelContractsTests
+{
+    [Fact]
+    public void BookAccessGrantRequest_Defaults_AreSafe()
+    {
+        var request = new BookAccessGrantRequest();
+
+        request.BookId.Should().BeEmpty();
+        request.PrincipalId.Should().BeEmpty();
+        request.AccessLevel.Should().BeEmpty();
+        request.ExpiresAt.Should().BeNull();
+        request.IdempotencyKey.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetBookAnalyticsRequest_Defaults_AreStable()
+    {
+        var request = new GetBookAnalyticsRequest();
+
+        request.BookId.Should().BeEmpty();
+        request.Granularity.Should().Be("day");
+        request.IncludeUniqueReaders.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ListBookAuditLogsRequest_Defaults_AreStable()
+    {
+        var request = new ListBookAuditLogsRequest();
+
+        request.Page.Should().Be(0);
+        request.PageSize.Should().Be(50);
+        request.ActorId.Should().BeNull();
+        request.CorrelationId.Should().BeNull();
+    }
+
+    [Fact]
+    public void WebhookRequests_SupportStronglyTypedEventLists()
+    {
+        Randomizer.Seed = new Random(17);
+        var faker = new Faker();
+        var events = new[] { faker.Hacker.Verb(), faker.Hacker.Verb() };
+
+        var registerRequest = new RegisterWebhookRequest
+        {
+            EndpointUrl = "https://hooks.example.com/publishing-platform",
+            Events = events,
+            SigningKeyId = "kid-01",
+        };
+
+        var updateRequest = new UpdateWebhookRequest
+        {
+            WebhookId = "whk-001",
+            EndpointUrl = registerRequest.EndpointUrl,
+            Events = registerRequest.Events,
+            IsActive = false,
+        };
+
+        registerRequest.Events.Should().HaveCount(2);
+        registerRequest.IsActive.Should().BeTrue();
+        updateRequest.WebhookId.Should().Be("whk-001");
+        updateRequest.IsActive.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AssetOperationRequests_ExposeIdempotencyAndIdentityFields()
+    {
+        var uploadRequest = new UploadBookAssetRequest
+        {
+            BookId = "book-01",
+            AssetType = "cover",
+            FileName = "cover.png",
+            ContentType = "image/png",
+            IdempotencyKey = "asset-upload-001",
+        };
+
+        var deleteRequest = new DeleteBookAssetRequest
+        {
+            BookId = uploadRequest.BookId,
+            AssetId = "asset-01",
+            Reason = "replace",
+        };
+
+        uploadRequest.IdempotencyKey.Should().Be("asset-upload-001");
+        deleteRequest.AssetId.Should().Be("asset-01");
+    }
+}

--- a/tests/PublishingPlatform.SDK.Tests/Models/RequestModelContractsTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Models/RequestModelContractsTests.cs
@@ -88,4 +88,49 @@ public sealed class RequestModelContractsTests
         uploadRequest.IdempotencyKey.Should().Be("asset-upload-001");
         deleteRequest.AssetId.Should().Be("asset-01");
     }
+
+    [Fact]
+    public void BookAccessRevokeRequest_Defaults_AreSafe()
+    {
+        var request = new BookAccessRevokeRequest();
+
+        request.BookId.Should().BeEmpty();
+        request.PrincipalId.Should().BeEmpty();
+        request.Reason.Should().BeNull();
+    }
+
+    [Fact]
+    public void RequestModels_AssignedValues_ArePreserved()
+    {
+        var from = DateTimeOffset.UtcNow.AddDays(-7);
+        var to = DateTimeOffset.UtcNow;
+
+        var analytics = new GetBookAnalyticsRequest
+        {
+            BookId = "book-22",
+            From = from,
+            To = to,
+            Granularity = "week",
+            IncludeUniqueReaders = false,
+        };
+
+        var audit = new ListBookAuditLogsRequest
+        {
+            BookId = "book-22",
+            ActorId = "actor-1",
+            Action = "book.updated",
+            From = from,
+            To = to,
+            CorrelationId = "corr-1",
+            Page = 2,
+            PageSize = 25,
+        };
+
+        analytics.BookId.Should().Be("book-22");
+        analytics.Granularity.Should().Be("week");
+        analytics.IncludeUniqueReaders.Should().BeFalse();
+        audit.Page.Should().Be(2);
+        audit.PageSize.Should().Be(25);
+        audit.CorrelationId.Should().Be("corr-1");
+    }
 }


### PR DESCRIPTION
What changed:
- Added new public request models:
  - `BookAccessGrantRequest`, `BookAccessRevokeRequest`
  - `GetBookAnalyticsRequest`
  - `ListBookAuditLogsRequest`
  - `UploadBookAssetRequest`, `DeleteBookAssetRequest`
  - `RegisterWebhookRequest`, `UpdateWebhookRequest`
- Expanded internal Google Books wire contracts with broader payload shapes:
  - `GoogleBooksVolumesResponsePayload`
  - `GoogleBooksImageLinksPayload`
  - `GoogleBooksIndustryIdentifierPayload`
  - extended `GoogleBooksVolumeInfoPayload` fields
- Extended static manual mapping with collection mapping (`ToBooks`) and category-to-tag propagation, while keeping provider models internal.
- Updated architecture boundary and contract tests for the new internal payloads and mapping behavior.
- Updated README module status sections to document available strongly typed request models for upcoming operations.

API impact:
- Public SDK model surface expanded with new `*Request` types.
- No new public client methods were introduced in this ticket.
- Google Books provider contracts remain internal and non-leaking.

# Validation

- [x] `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal`
- [x] Added/updated tests for request model defaults, Google mapping behavior, and internal visibility boundaries

Test result evidence:
- Passed: 128
- Failed: 0
- Skipped: 0

# Release Please Override (Required for releasable changes)

```text
BEGIN_COMMIT_OVERRIDE
feat: add strongly typed request models and expand internal google books mappings
END_COMMIT_OVERRIDE
```

# Manual NuGet Publish

1. Confirm `Directory.Build.props` version equals the intended release version.
2. Create matching tag `v<version>` on the exact commit to publish.
3. Run the `Publish NuGet` workflow manually with the same tag.
4. Verify the published package version appears on NuGet.
