### PR TITLE
RPS-51 fix:  turning `IBookDistributionClient` from a placeholder into a full operational workflow client, while preserving the architectural separation from `IBookPublishingClient`.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.9</Version>
+    <Version>0.0.10</Version>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Runnable scripts are available in:
 - `examples/BasicUsage/BuilderInitializationExample.csx`
 - `examples/BasicUsage/DiInitializationExample.csx`
 - `examples/BookPublishing/BookPublishingExample.csx`
+- `examples/BookDistribution/BookDistributionExample.csx`
 
 ## Client modules: available properties and use cases
 
@@ -173,16 +174,18 @@ Typical use cases:
 
 Module accessor for downstream distribution workflows.
 
-Current status:
+Available operations:
 
-- Property is available on the root client.
-- Interface is currently a placeholder (no public operations yet in this SDK version).
-- Strongly typed request models are available for upcoming analytics queries (`GetBookAnalyticsRequest`).
+- `StartAsync(...)`: start distribution to one or more channels.
+- `GetStatusAsync(...)`: fetch the current state of a distribution operation.
+- `RetryAsync(...)`: retry a previous distribution operation.
+- `ListAsync(...)`: list tracked distribution operations for a book.
 
-Typical use cases once expanded:
+Typical use cases:
 
-- Pushing books to channels/partners.
-- Tracking distribution outcome and status.
+- Pushing published books to partner channels, mobile catalog feeds, and CDN-oriented pipelines.
+- Tracking long-running delivery progress and failures by operation id.
+- Retrying failed distribution workflows without re-running the publishing lifecycle.
 
 ### `BookAccess` (`IBookAccessClient`)
 
@@ -260,7 +263,50 @@ Typical use cases once expanded:
 ## Which module should I use?
 
 - Use `Books` today for production book CRUD/listing flows.
-- Use other module properties as stable access points in your codebase while their operation surfaces are being expanded in upcoming SDK iterations.
+- Use `BookPublishing` when you need lifecycle state transitions (`publish`, `unpublish`, `schedule`).
+- Use `BookDistribution` when you need downstream propagation and operational delivery tracking.
+
+## Publishing vs distribution architecture
+
+`BookPublishing` and `BookDistribution` are intentionally separate concerns.
+
+- `BookPublishing` controls domain lifecycle state (`Draft -> Published`, schedule, unpublish).
+- `BookDistribution` controls operational delivery workflows (channel propagation, retries, status polling, operation history).
+
+Correlation model:
+
+- Shared identity: both modules operate on the same `bookId`.
+- Independent state machines: publishing status and distribution status are tracked separately.
+- Long-running traceability: distribution returns an `operationId` used for polling, retries, and diagnostics.
+- Business precondition: successful publication is a backend precondition for distribution, not a client-side coupling.
+
+This separation improves observability, retry safety, and failure isolation for partner/channel sync workflows.
+
+### Side-by-side API usage
+
+```csharp
+var publishingStatus = await client.BookPublishing.PublishAsync(
+    bookId,
+    new PublishBookRequest { Notes = "Ready for release" },
+    idempotencyKey: "pub-001");
+
+if (!string.Equals(publishingStatus.Status, "published", StringComparison.OrdinalIgnoreCase))
+{
+    return;
+}
+
+var distributionStart = await client.BookDistribution.StartAsync(
+    bookId,
+    new StartBookDistributionRequest
+    {
+        Channels = ["mobile", "partner-store"],
+    },
+    idempotencyKey: "dist-001");
+
+var distributionStatus = await client.BookDistribution.GetStatusAsync(
+    bookId,
+    distributionStart.OperationId);
+```
 
 ## Books lifecycle usage
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,6 +20,21 @@ The current implementation provides the shared client foundation. The deeper boo
 
 The module clients are wired through dependency injection and the direct builder path. Their concrete classes currently share the same internal transport foundation, while detailed module operations are still evolving through the implementation backlog.
 
+### Publishing And Distribution Separation
+
+`BookPublishing` and `BookDistribution` are separate by design:
+
+- `BookPublishing` owns lifecycle transitions and answers "is this book published?".
+- `BookDistribution` owns downstream delivery workflows and answers "where is this published book delivered?".
+
+Correlation rules:
+
+- Shared `bookId` links lifecycle and distribution concerns.
+- Distribution uses `operationId` as the long-running workflow identity.
+- Publishing success is a business precondition for distribution at backend level, not a merged client state machine.
+
+This split keeps lifecycle state changes isolated from partner/channel operational failures, enabling safer retries and clearer diagnostics.
+
 Consumers can create the SDK in two supported ways:
 
 - Hosted applications use `AddPublishingPlatformClient()` with `IOptions<PublishingPlatformClientOptions>`.

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -26,6 +26,19 @@ All module clients should use the shared internal HTTP transport. This trades so
 
 The benefit is a single place for correlation IDs, JSON request conventions, resilience, and error normalization. Module clients should focus on request validation, endpoint shape, and response mapping.
 
+## Publishing Lifecycle And Distribution Workflow Separation
+
+Status: Accepted.
+
+Publishing and distribution are separate concerns in the SDK surface.
+
+- Publishing is domain lifecycle state transition (`Publish`, `Unpublish`, `Schedule`, lifecycle status).
+- Distribution is operational propagation workflow (`Start`, `GetStatus`, `Retry`, list operations/history).
+
+Both concerns correlate through `bookId`, while distribution additionally introduces an `operationId` for long-running delivery tracking.
+
+This avoids overloaded "publish" behavior, improves retry safety, and isolates downstream partner failures from lifecycle state management.
+
 ## Options Pattern And Direct Builder
 
 Status: Accepted.

--- a/examples/BookDistribution/BookDistributionExample.csx
+++ b/examples/BookDistribution/BookDistributionExample.csx
@@ -1,0 +1,34 @@
+//r "nuget: PublishingPlatform.SDK"
+
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Options;
+
+var client = PublishingPlatformClientBuilder.Create(new PublishingPlatformClientOptions
+{
+    BaseUrl = "https://api.books.example",
+    ApiKey = "your-api-key",
+}).Build();
+
+var start = await client.BookDistribution.StartAsync(
+    "book-123",
+    new StartBookDistributionRequest
+    {
+        Channels = ["mobile", "partner-store"],
+    },
+    idempotencyKey: "distribution-book-123-1");
+
+Console.WriteLine($"Distribution operation id: {start.OperationId}, status: {start.Status}");
+
+var status = await client.BookDistribution.GetStatusAsync("book-123", start.OperationId);
+Console.WriteLine($"Distribution status: {status.Status}");
+
+var retry = await client.BookDistribution.RetryAsync(
+    "book-123",
+    start.OperationId,
+    idempotencyKey: "distribution-retry-book-123-1");
+
+Console.WriteLine($"Retry status: {retry.Status}");
+
+var history = await client.BookDistribution.ListAsync("book-123");
+Console.WriteLine($"Tracked distribution operations: {history.Operations.Count}");

--- a/examples/BookDistribution/README.md
+++ b/examples/BookDistribution/README.md
@@ -1,0 +1,12 @@
+# BookDistribution Example
+
+This example demonstrates operational distribution workflows through `IBookDistributionClient`:
+
+- `StartAsync(...)`
+- `GetStatusAsync(...)`
+- `RetryAsync(...)`
+- `ListAsync(...)`
+
+Run:
+
+- `examples/BookDistribution/BookDistributionExample.csx`

--- a/src/PublishingPlatform.SDK/Abstractions/IBookDistributionClient.cs
+++ b/src/PublishingPlatform.SDK/Abstractions/IBookDistributionClient.cs
@@ -1,5 +1,46 @@
-﻿namespace PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Models;
 
+namespace PublishingPlatform.SDK.Abstractions;
+
+/// <summary>
+/// Provides operational workflows for distributing published books to delivery channels.
+/// </summary>
 public interface IBookDistributionClient
 {
+    /// <summary>
+    /// Starts a book distribution operation for one or more channels.
+    /// </summary>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="request">The distribution start payload.</param>
+    /// <param name="idempotencyKey">An optional idempotency key for safe retries.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The created distribution operation snapshot.</returns>
+    Task<BookDistributionOperation> StartAsync(string bookId, StartBookDistributionRequest request, string? idempotencyKey = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the status of a specific distribution operation.
+    /// </summary>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="operationId">The unique distribution operation identifier.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The distribution operation snapshot.</returns>
+    Task<BookDistributionOperation> GetStatusAsync(string bookId, string operationId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Retries a previously failed or incomplete distribution operation.
+    /// </summary>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="operationId">The unique distribution operation identifier.</param>
+    /// <param name="idempotencyKey">An optional idempotency key for safe retries.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The distribution operation snapshot after retry.</returns>
+    Task<BookDistributionOperation> RetryAsync(string bookId, string operationId, string? idempotencyKey = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists tracked distribution operations for a specific book.
+    /// </summary>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>A list wrapper containing distribution operations.</returns>
+    Task<BookDistributionListResult> ListAsync(string bookId, CancellationToken ct = default);
 }

--- a/src/PublishingPlatform.SDK/Clients/BookDistribution/Requests/DefaultBookDistributionRequestHeadersFactory.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookDistribution/Requests/DefaultBookDistributionRequestHeadersFactory.cs
@@ -1,0 +1,23 @@
+namespace PublishingPlatform.SDK.Clients.BookDistribution.Requests;
+
+/// <summary>
+/// Produces header sets for book distribution requests.
+/// </summary>
+internal sealed class DefaultBookDistributionRequestHeadersFactory : IBookDistributionRequestHeadersFactory
+{
+    private const string IdempotencyHeaderName = "Idempotency-Key";
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<string, string>? CreateIdempotencyHeaders(string? idempotencyKey)
+    {
+        if (string.IsNullOrWhiteSpace(idempotencyKey))
+        {
+            return null;
+        }
+
+        return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [IdempotencyHeaderName] = idempotencyKey,
+        };
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/BookDistribution/Requests/IBookDistributionRequestHeadersFactory.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookDistribution/Requests/IBookDistributionRequestHeadersFactory.cs
@@ -1,0 +1,14 @@
+namespace PublishingPlatform.SDK.Clients.BookDistribution.Requests;
+
+/// <summary>
+/// Creates request headers for book distribution transport calls.
+/// </summary>
+internal interface IBookDistributionRequestHeadersFactory
+{
+    /// <summary>
+    /// Creates idempotency headers when an idempotency key is provided.
+    /// </summary>
+    /// <param name="idempotencyKey">The optional idempotency key.</param>
+    /// <returns>A headers dictionary, or <see langword="null"/> when no headers are needed.</returns>
+    IReadOnlyDictionary<string, string>? CreateIdempotencyHeaders(string? idempotencyKey);
+}

--- a/src/PublishingPlatform.SDK/Clients/BookDistribution/Serialization/DefaultBookDistributionResponseReader.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookDistribution/Serialization/DefaultBookDistributionResponseReader.cs
@@ -1,0 +1,35 @@
+using System.Net.Http.Json;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookDistribution.Serialization;
+
+/// <summary>
+/// Parses distribution responses and enforces non-empty payloads.
+/// </summary>
+internal sealed class DefaultBookDistributionResponseReader : IBookDistributionResponseReader
+{
+    /// <inheritdoc />
+    public async Task<BookDistributionOperation> ReadOperationAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        var operation = await response.Content.ReadFromJsonAsync<BookDistributionOperation>(ct).ConfigureAwait(false);
+        if (operation is null)
+        {
+            throw new BookValidationException("Book distribution operation payload was empty.");
+        }
+
+        return operation;
+    }
+
+    /// <inheritdoc />
+    public async Task<BookDistributionListResult> ReadListAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        var list = await response.Content.ReadFromJsonAsync<BookDistributionListResult>(ct).ConfigureAwait(false);
+        if (list is null)
+        {
+            throw new BookValidationException("Book distribution list payload was empty.");
+        }
+
+        return list;
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/BookDistribution/Serialization/IBookDistributionResponseReader.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookDistribution/Serialization/IBookDistributionResponseReader.cs
@@ -1,0 +1,25 @@
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookDistribution.Serialization;
+
+/// <summary>
+/// Reads and validates distribution response payloads.
+/// </summary>
+internal interface IBookDistributionResponseReader
+{
+    /// <summary>
+    /// Reads a distribution operation payload from an HTTP response.
+    /// </summary>
+    /// <param name="response">The HTTP response.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The parsed <see cref="BookDistributionOperation"/>.</returns>
+    Task<BookDistributionOperation> ReadOperationAsync(HttpResponseMessage response, CancellationToken ct);
+
+    /// <summary>
+    /// Reads a distribution operation list payload from an HTTP response.
+    /// </summary>
+    /// <param name="response">The HTTP response.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The parsed <see cref="BookDistributionListResult"/>.</returns>
+    Task<BookDistributionListResult> ReadListAsync(HttpResponseMessage response, CancellationToken ct);
+}

--- a/src/PublishingPlatform.SDK/Clients/BookDistribution/Validation/DefaultBookDistributionRequestValidator.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookDistribution/Validation/DefaultBookDistributionRequestValidator.cs
@@ -1,0 +1,45 @@
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookDistribution.Validation;
+
+/// <summary>
+/// Enforces input validation rules for book distribution operations.
+/// </summary>
+internal sealed class DefaultBookDistributionRequestValidator : IBookDistributionRequestValidator
+{
+    /// <inheritdoc />
+    public void ValidateBookId(string bookId)
+    {
+        if (string.IsNullOrWhiteSpace(bookId))
+        {
+            throw new BookValidationException("Book id is required.");
+        }
+    }
+
+    /// <inheritdoc />
+    public void ValidateOperationId(string operationId)
+    {
+        if (string.IsNullOrWhiteSpace(operationId))
+        {
+            throw new BookValidationException("Distribution operation id is required.");
+        }
+    }
+
+    /// <inheritdoc />
+    public void ValidateStartRequest(StartBookDistributionRequest request)
+    {
+        if (request.Channels.Count == 0)
+        {
+            throw new BookValidationException("At least one distribution channel is required.");
+        }
+
+        foreach (var channel in request.Channels)
+        {
+            if (string.IsNullOrWhiteSpace(channel))
+            {
+                throw new BookValidationException("Distribution channels cannot contain empty values.");
+            }
+        }
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/BookDistribution/Validation/DefaultBookDistributionRequestValidator.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookDistribution/Validation/DefaultBookDistributionRequestValidator.cs
@@ -34,12 +34,9 @@ internal sealed class DefaultBookDistributionRequestValidator : IBookDistributio
             throw new BookValidationException("At least one distribution channel is required.");
         }
 
-        foreach (var channel in request.Channels)
+        if (request.Channels.Any(string.IsNullOrWhiteSpace))
         {
-            if (string.IsNullOrWhiteSpace(channel))
-            {
-                throw new BookValidationException("Distribution channels cannot contain empty values.");
-            }
+            throw new BookValidationException("Distribution channels cannot contain empty values.");
         }
     }
 }

--- a/src/PublishingPlatform.SDK/Clients/BookDistribution/Validation/IBookDistributionRequestValidator.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookDistribution/Validation/IBookDistributionRequestValidator.cs
@@ -1,0 +1,27 @@
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookDistribution.Validation;
+
+/// <summary>
+/// Validates book distribution request inputs before transport execution.
+/// </summary>
+internal interface IBookDistributionRequestValidator
+{
+    /// <summary>
+    /// Validates the book identifier.
+    /// </summary>
+    /// <param name="bookId">The book identifier value.</param>
+    void ValidateBookId(string bookId);
+
+    /// <summary>
+    /// Validates the operation identifier.
+    /// </summary>
+    /// <param name="operationId">The operation identifier value.</param>
+    void ValidateOperationId(string operationId);
+
+    /// <summary>
+    /// Validates a distribution start request payload.
+    /// </summary>
+    /// <param name="request">The distribution start request payload.</param>
+    void ValidateStartRequest(StartBookDistributionRequest request);
+}

--- a/src/PublishingPlatform.SDK/Clients/BookDistributionClient.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookDistributionClient.cs
@@ -1,14 +1,131 @@
+using System.Diagnostics;
+using System.Net.Http.Json;
 using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Clients.BookDistribution.Requests;
+using PublishingPlatform.SDK.Clients.BookDistribution.Serialization;
+using PublishingPlatform.SDK.Clients.BookDistribution.Validation;
+using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Transport;
+using PublishingPlatform.SDK.Internal;
+using PublishingPlatform.SDK.Models;
 
 namespace PublishingPlatform.SDK.Clients;
 
+/// <summary>
+/// Implements operational distribution workflows using the shared SDK transport.
+/// </summary>
 public sealed class BookDistributionClient : IBookDistributionClient
 {
+    private const string StartOperationName = "BookDistribution.Start";
+    private const string GetStatusOperationName = "BookDistribution.GetStatus";
+    private const string RetryOperationName = "BookDistribution.Retry";
+    private const string ListOperationName = "BookDistribution.List";
+
     private readonly ISharedHttpTransport _transport;
+    private readonly IBookDistributionRequestValidator _validator;
+    private readonly IBookDistributionRequestHeadersFactory _requestHeadersFactory;
+    private readonly IBookDistributionResponseReader _responseReader;
 
     internal BookDistributionClient(ISharedHttpTransport transport)
+        : this(
+            transport,
+            new DefaultBookDistributionRequestValidator(),
+            new DefaultBookDistributionRequestHeadersFactory(),
+            new DefaultBookDistributionResponseReader())
+    {
+    }
+
+    internal BookDistributionClient(
+        ISharedHttpTransport transport,
+        IBookDistributionRequestValidator validator,
+        IBookDistributionRequestHeadersFactory requestHeadersFactory,
+        IBookDistributionResponseReader responseReader)
     {
         _transport = transport;
+        _validator = validator;
+        _requestHeadersFactory = requestHeadersFactory;
+        _responseReader = responseReader;
+    }
+
+    /// <inheritdoc />
+    public async Task<BookDistributionOperation> StartAsync(string bookId, StartBookDistributionRequest request, string? idempotencyKey = null, CancellationToken ct = default)
+    {
+        _validator.ValidateBookId(bookId);
+        Guards.NotNull(request, nameof(request));
+        _validator.ValidateStartRequest(request);
+
+        using var activity = StartActivity(StartOperationName);
+        var headers = _requestHeadersFactory.CreateIdempotencyHeaders(idempotencyKey);
+        var content = JsonContent.Create(request);
+        using var response = await _transport.SendAsync(
+            HttpMethod.Post,
+            $"/books/{Uri.EscapeDataString(bookId)}/distribution/start",
+            content,
+            headers,
+            StartOperationName,
+            ct).ConfigureAwait(false);
+
+        return await _responseReader.ReadOperationAsync(response, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<BookDistributionOperation> GetStatusAsync(string bookId, string operationId, CancellationToken ct = default)
+    {
+        _validator.ValidateBookId(bookId);
+        _validator.ValidateOperationId(operationId);
+
+        using var activity = StartActivity(GetStatusOperationName);
+        using var response = await _transport.SendAsync(
+            HttpMethod.Get,
+            $"/books/{Uri.EscapeDataString(bookId)}/distribution/{Uri.EscapeDataString(operationId)}/status",
+            null,
+            null,
+            GetStatusOperationName,
+            ct).ConfigureAwait(false);
+
+        return await _responseReader.ReadOperationAsync(response, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<BookDistributionOperation> RetryAsync(string bookId, string operationId, string? idempotencyKey = null, CancellationToken ct = default)
+    {
+        _validator.ValidateBookId(bookId);
+        _validator.ValidateOperationId(operationId);
+
+        using var activity = StartActivity(RetryOperationName);
+        var headers = _requestHeadersFactory.CreateIdempotencyHeaders(idempotencyKey);
+        using var response = await _transport.SendAsync(
+            HttpMethod.Post,
+            $"/books/{Uri.EscapeDataString(bookId)}/distribution/{Uri.EscapeDataString(operationId)}/retry",
+            null,
+            headers,
+            RetryOperationName,
+            ct).ConfigureAwait(false);
+
+        return await _responseReader.ReadOperationAsync(response, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<BookDistributionListResult> ListAsync(string bookId, CancellationToken ct = default)
+    {
+        _validator.ValidateBookId(bookId);
+
+        using var activity = StartActivity(ListOperationName);
+        using var response = await _transport.SendAsync(
+            HttpMethod.Get,
+            $"/books/{Uri.EscapeDataString(bookId)}/distribution",
+            null,
+            null,
+            ListOperationName,
+            ct).ConfigureAwait(false);
+
+        return await _responseReader.ReadListAsync(response, ct).ConfigureAwait(false);
+    }
+
+    private static Activity? StartActivity(string operationName)
+    {
+        var activity = ActivitySourceProvider.ActivitySource.StartActivity(operationName, ActivityKind.Client);
+        activity?.SetTag("sdk.operation", operationName);
+        return activity;
     }
 }

--- a/src/PublishingPlatform.SDK/Models/BookDistributionListResult.cs
+++ b/src/PublishingPlatform.SDK/Models/BookDistributionListResult.cs
@@ -1,0 +1,12 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents a collection of distribution operation snapshots for a book.
+/// </summary>
+public sealed class BookDistributionListResult
+{
+    /// <summary>
+    /// Gets or sets the returned operations.
+    /// </summary>
+    public IReadOnlyList<BookDistributionOperation> Operations { get; set; } = Array.Empty<BookDistributionOperation>();
+}

--- a/src/PublishingPlatform.SDK/Models/BookDistributionOperation.cs
+++ b/src/PublishingPlatform.SDK/Models/BookDistributionOperation.cs
@@ -1,0 +1,37 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents a single distribution operation snapshot for a book.
+/// </summary>
+public sealed class BookDistributionOperation
+{
+    /// <summary>
+    /// Gets or sets the unique operation identifier.
+    /// </summary>
+    public string OperationId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the unique book identifier.
+    /// </summary>
+    public string BookId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the distribution status.
+    /// </summary>
+    public DistributionStatus Status { get; set; } = DistributionStatus.Unknown;
+
+    /// <summary>
+    /// Gets or sets the operation start timestamp.
+    /// </summary>
+    public DateTimeOffset? StartedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the operation completion timestamp.
+    /// </summary>
+    public DateTimeOffset? CompletedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional failure reason.
+    /// </summary>
+    public string? FailureReason { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Models/StartBookDistributionRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/StartBookDistributionRequest.cs
@@ -1,0 +1,12 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents a request to start distribution for a book.
+/// </summary>
+public sealed class StartBookDistributionRequest
+{
+    /// <summary>
+    /// Gets or sets destination channel identifiers.
+    /// </summary>
+    public IReadOnlyList<string> Channels { get; set; } = Array.Empty<string>();
+}

--- a/tests/PublishingPlatform.SDK.Tests/BookDistribution/BookDistributionClientTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/BookDistribution/BookDistributionClientTests.cs
@@ -1,0 +1,327 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using Bogus;
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Infrastructure.Errors;
+using PublishingPlatform.SDK.Infrastructure.Transport;
+using PublishingPlatform.SDK.Internal.Resilience;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Tests.BookDistribution;
+
+public sealed class BookDistributionClientTests
+{
+    [Fact]
+    public async Task StartAsync_SendsPostToExpectedPath_WithIdempotencyHeader()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+                HttpMethod.Post,
+                "/books/book-1/distribution/start",
+                Arg.Any<HttpContent>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                "BookDistribution.Start",
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new BookDistributionOperation { BookId = "book-1", OperationId = "op-1", Status = DistributionStatus.Pending }),
+            }));
+
+        var sut = new BookDistributionClient(transport);
+
+        var result = await sut.StartAsync("book-1", CreateStartRequest(), "idem-start");
+
+        result.OperationId.Should().Be("op-1");
+        await transport.Received(1).SendAsync(
+            HttpMethod.Post,
+            "/books/book-1/distribution/start",
+            Arg.Any<HttpContent>(),
+            Arg.Is<IReadOnlyDictionary<string, string>>(h => h["Idempotency-Key"] == "idem-start"),
+            "BookDistribution.Start",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_SendsGetToExpectedPath()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+                HttpMethod.Get,
+                "/books/book-2/distribution/op-9/status",
+                null,
+                null,
+                "BookDistribution.GetStatus",
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new BookDistributionOperation { BookId = "book-2", OperationId = "op-9", Status = DistributionStatus.Completed }),
+            }));
+
+        var sut = new BookDistributionClient(transport);
+
+        var result = await sut.GetStatusAsync("book-2", "op-9");
+
+        result.Status.Should().Be(DistributionStatus.Completed);
+        await transport.Received(1).SendAsync(
+            HttpMethod.Get,
+            "/books/book-2/distribution/op-9/status",
+            null,
+            null,
+            "BookDistribution.GetStatus",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RetryAsync_SendsPostToExpectedPath_WithIdempotencyHeader()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+                HttpMethod.Post,
+                "/books/book-3/distribution/op-7/retry",
+                null,
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                "BookDistribution.Retry",
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new BookDistributionOperation { BookId = "book-3", OperationId = "op-7", Status = DistributionStatus.InProgress }),
+            }));
+
+        var sut = new BookDistributionClient(transport);
+
+        var result = await sut.RetryAsync("book-3", "op-7", "idem-retry");
+
+        result.Status.Should().Be(DistributionStatus.InProgress);
+        await transport.Received(1).SendAsync(
+            HttpMethod.Post,
+            "/books/book-3/distribution/op-7/retry",
+            null,
+            Arg.Is<IReadOnlyDictionary<string, string>>(h => h["Idempotency-Key"] == "idem-retry"),
+            "BookDistribution.Retry",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListAsync_SendsGetToExpectedPath()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+                HttpMethod.Get,
+                "/books/book-4/distribution",
+                null,
+                null,
+                "BookDistribution.List",
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new BookDistributionListResult
+                {
+                    Operations =
+                    [
+                        new BookDistributionOperation { BookId = "book-4", OperationId = "op-1", Status = DistributionStatus.Pending },
+                    ],
+                }),
+            }));
+
+        var sut = new BookDistributionClient(transport);
+
+        var result = await sut.ListAsync("book-4");
+
+        result.Operations.Should().HaveCount(1);
+        await transport.Received(1).SendAsync(
+            HttpMethod.Get,
+            "/books/book-4/distribution",
+            null,
+            null,
+            "BookDistribution.List",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task StartAsync_ThrowsBookValidationException_ForInvalidBookId(string bookId)
+    {
+        var sut = new BookDistributionClient(Substitute.For<ISharedHttpTransport>());
+
+        var act = async () => await sut.StartAsync(bookId, CreateStartRequest());
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Book id is required");
+    }
+
+    [Fact]
+    public async Task StartAsync_ThrowsArgumentNullException_ForNullRequest()
+    {
+        var sut = new BookDistributionClient(Substitute.For<ISharedHttpTransport>());
+
+        var act = async () => await sut.StartAsync("book-1", null!);
+
+        _ = await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task StartAsync_ThrowsBookValidationException_ForMissingChannels()
+    {
+        var sut = new BookDistributionClient(Substitute.For<ISharedHttpTransport>());
+
+        var act = async () => await sut.StartAsync("book-1", new StartBookDistributionRequest());
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("At least one distribution channel is required");
+    }
+
+    [Fact]
+    public async Task StartAsync_ThrowsBookValidationException_ForWhitespaceChannel()
+    {
+        var sut = new BookDistributionClient(Substitute.For<ISharedHttpTransport>());
+
+        var act = async () => await sut.StartAsync("book-1", new StartBookDistributionRequest { Channels = [CreateStartRequest().Channels[0], " "] });
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Distribution channels cannot contain empty values");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task GetStatusAsync_ThrowsBookValidationException_ForInvalidOperationId(string operationId)
+    {
+        var sut = new BookDistributionClient(Substitute.For<ISharedHttpTransport>());
+
+        var act = async () => await sut.GetStatusAsync("book-1", operationId);
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Distribution operation id is required");
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_ThrowsBookValidationException_WhenResponsePayloadIsNull()
+    {
+        using var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, "application/json"),
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.test") };
+        var transport = new SharedHttpTransport(client, new NoOpPublishingPlatformResiliencePipeline(), new FixedCorrelationIdProvider(), new DefaultPublishingPlatformErrorMapper());
+        var sut = new BookDistributionClient(transport);
+
+        var act = async () => await sut.GetStatusAsync("book-null", "op-null");
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Book distribution operation payload was empty");
+    }
+
+    [Fact]
+    public async Task ListAsync_ThrowsBookValidationException_WhenResponsePayloadIsNull()
+    {
+        using var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, "application/json"),
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.test") };
+        var transport = new SharedHttpTransport(client, new NoOpPublishingPlatformResiliencePipeline(), new FixedCorrelationIdProvider(), new DefaultPublishingPlatformErrorMapper());
+        var sut = new BookDistributionClient(transport);
+
+        var act = async () => await sut.ListAsync("book-null");
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Book distribution list payload was empty");
+    }
+
+    [Fact]
+    public async Task DefaultErrorMapper_Maps404ToBookNotFound_ForStart()
+    {
+        using var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = JsonContent.Create(new { Message = "missing" }),
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.test") };
+        var transport = new SharedHttpTransport(client, new NoOpPublishingPlatformResiliencePipeline(), new FixedCorrelationIdProvider(), new DefaultPublishingPlatformErrorMapper());
+        var sut = new BookDistributionClient(transport);
+
+        var act = async () => await sut.StartAsync("book-404", CreateStartRequest());
+
+        _ = await act.Should().ThrowAsync<BookNotFoundException>();
+    }
+
+    [Fact]
+    public async Task DefaultErrorMapper_Maps409ToBookConflict_ForGetStatus()
+    {
+        using var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.Conflict)
+        {
+            Content = JsonContent.Create(new { Message = "conflict" }),
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.test") };
+        var transport = new SharedHttpTransport(client, new NoOpPublishingPlatformResiliencePipeline(), new FixedCorrelationIdProvider(), new DefaultPublishingPlatformErrorMapper());
+        var sut = new BookDistributionClient(transport);
+
+        var act = async () => await sut.GetStatusAsync("book-409", "op-1");
+
+        _ = await act.Should().ThrowAsync<BookConflictException>();
+    }
+
+    [Fact]
+    public async Task DefaultErrorMapper_Maps429ToBookRateLimited_ForRetry()
+    {
+        using var handler = new SingleResponseHandler(new HttpResponseMessage((HttpStatusCode)429)
+        {
+            Content = JsonContent.Create(new { Message = "too many requests" }),
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.test") };
+        var transport = new SharedHttpTransport(client, new NoOpPublishingPlatformResiliencePipeline(), new FixedCorrelationIdProvider(), new DefaultPublishingPlatformErrorMapper());
+        var sut = new BookDistributionClient(transport);
+
+        var act = async () => await sut.RetryAsync("book-429", "op-1");
+
+        _ = await act.Should().ThrowAsync<BookRateLimitedException>();
+    }
+
+    [Fact]
+    public async Task ValidationFailure_DoesNotCallTransport()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        var sut = new BookDistributionClient(transport);
+
+        var act = async () => await sut.RetryAsync(" ", "op-1");
+
+        _ = await act.Should().ThrowAsync<BookValidationException>();
+        await transport.DidNotReceiveWithAnyArgs().SendAsync(default!, default!, default, default, default!, default);
+    }
+
+    private sealed class SingleResponseHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+
+        public SingleResponseHandler(HttpResponseMessage response)
+        {
+            _response = response;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_response);
+        }
+    }
+
+    private sealed class FixedCorrelationIdProvider : ICorrelationIdProvider
+    {
+        public string Create()
+        {
+            return Guid.NewGuid().ToString("N");
+        }
+    }
+
+    private static StartBookDistributionRequest CreateStartRequest()
+    {
+        Randomizer.Seed = new Random(51);
+        var faker = new Faker();
+        var channel = faker.PickRandom("mobile", "partner-store", "cdn");
+        return new StartBookDistributionRequest
+        {
+            Channels = [channel],
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Expanded `IBookDistributionClient` with:
  - `StartAsync(...)`
  - `GetStatusAsync(...)`
  - `RetryAsync(...)`
  - `ListAsync(...)`
- Added distribution models:
  - `StartBookDistributionRequest`
  - `BookDistributionOperation`
  - `BookDistributionListResult`
- Implemented `BookDistributionClient` orchestration over shared transport with:
  - route consistency
  - idempotency header support for mutating operations
  - explicit input validation
  - dedicated response reading
  - diagnostics operation naming
- Added distribution collaborator seams:
  - request validator
  - request headers factory
  - response reader
- Added comprehensive `BookDistributionClientTests` for happy path, guard clauses, null payload handling, and 404/409/429 error mapping.
- Updated `README.md` and architecture docs with a dedicated explanation of publishing-vs-distribution responsibilities and correlation model.
- Added consumer example:
  - `examples/BookDistribution/BookDistributionExample.csx`

API impact:

- Public interface change: `IBookDistributionClient` now exposes operational distribution methods.
- New public model types added under `PublishingPlatform.SDK.Models`.

# Validation

- [x] `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal --filter "FullyQualifiedName~BookDistributionClientTests"` (Passed: 17, Failed: 0)
- [x] `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal` (Passed: 150, Failed: 0)
- [x] `dotnet build src/PublishingPlatform.SDK/PublishingPlatform.SDK.csproj -v minimal` (Build succeeded, 0 warnings, 0 errors)

# Release Please Override (Required for releasable changes)

```text
BEGIN_COMMIT_OVERRIDE
fix: implement book distribution workflow client
END_COMMIT_OVERRIDE
```

# Manual NuGet Publish

1. Confirm `Directory.Build.props` version equals intended release version.
2. Create matching tag `v<version>` on this exact commit.
3. Run `Publish NuGet` workflow manually with that tag.
4. Verify the package version appears on NuGet.
