### PR TITLE
RPS-52 fix: Implement the `BookAccess` SDK module as the entitlement/access-control client for books.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.10</Version>
+    <Version>0.0.11</Version>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -191,16 +191,18 @@ Typical use cases:
 
 Module accessor for access-control and entitlement-related workflows.
 
-Current status:
+Available operations:
 
-- Property is available on the root client.
-- Interface is currently a placeholder (no public operations yet in this SDK version).
-- Strongly typed request models are available for upcoming audit log queries (`ListBookAuditLogsRequest`).
+- `GrantAsync(...)`: grant entitlement for a principal to a specific book.
+- `RevokeAsync(...)`: revoke entitlement for a principal and book.
+- `CheckAsync(...)`: check effective access for a principal and book.
+- `ListAsync(...)`: list access grants for a specific book or globally.
 
-Typical use cases once expanded:
+Typical use cases:
 
 - Access policy assignment.
 - Reader or tenant entitlement operations.
+- Support diagnostics for entitlement-denied scenarios.
 
 ### `BookAnalytics` (`IBookAnalyticsClient`)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ The current implementation provides the shared client foundation. The deeper boo
 - `BookAssets`
 - `Webhooks`
 
-The module clients are wired through dependency injection and the direct builder path. Their concrete classes currently share the same internal transport foundation, while detailed module operations are still evolving through the implementation backlog.
+The module clients are wired through dependency injection and the direct builder path. Their concrete classes currently share the same internal transport foundation, while detailed module operations continue to expand through the implementation backlog. `BookAccess` now provides concrete entitlement operations (grant, revoke, check, list) on top of this shared transport.
 
 ### Publishing And Distribution Separation
 

--- a/src/PublishingPlatform.SDK/Abstractions/IBookAccessClient.cs
+++ b/src/PublishingPlatform.SDK/Abstractions/IBookAccessClient.cs
@@ -1,5 +1,50 @@
-﻿namespace PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Models.Common;
 
+namespace PublishingPlatform.SDK.Abstractions;
+
+/// <summary>
+/// Provides entitlement and access-control operations for books.
+/// </summary>
 public interface IBookAccessClient
 {
+    /// <summary>
+    /// Grants access to a principal for a specific book.
+    /// </summary>
+    /// <param name="request">The grant request payload.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The resulting access grant outcome.</returns>
+    Task<BookAccessGrantResult> GrantAsync(
+        BookAccessGrantRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Revokes access from a principal for a specific book.
+    /// </summary>
+    /// <param name="request">The revoke request payload.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The resulting revoke outcome.</returns>
+    Task<BookAccessRevokeResult> RevokeAsync(
+        BookAccessRevokeRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks effective access for a principal and book combination.
+    /// </summary>
+    /// <param name="request">The check request payload.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The effective access status.</returns>
+    Task<BookAccessStatus> CheckAsync(
+        BookAccessCheckRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists book access grants with optional global scope.
+    /// </summary>
+    /// <param name="request">The list request criteria.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A paged result of access grants.</returns>
+    Task<PagedResult<BookAccessGrant>> ListAsync(
+        ListBookAccessRequest request,
+        CancellationToken cancellationToken = default);
 }

--- a/src/PublishingPlatform.SDK/Clients/BookAccess/Serialization/DefaultBookAccessQueryStringBuilder.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAccess/Serialization/DefaultBookAccessQueryStringBuilder.cs
@@ -1,0 +1,58 @@
+using System.Text;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookAccess.Serialization;
+
+/// <summary>
+/// Builds deterministic book access query paths.
+/// </summary>
+internal sealed class DefaultBookAccessQueryStringBuilder : IBookAccessQueryStringBuilder
+{
+    /// <inheritdoc />
+    public string BuildCheckPath(BookAccessCheckRequest request)
+    {
+        var builder = new StringBuilder($"/books/{Uri.EscapeDataString(request.BookId)}/access/check?");
+        builder.Append("principalId=");
+        builder.Append(Uri.EscapeDataString(request.PrincipalId));
+        builder.Append("&principalType=");
+        builder.Append(Uri.EscapeDataString(request.PrincipalType));
+        return builder.ToString();
+    }
+
+    /// <inheritdoc />
+    public string BuildListPath(ListBookAccessRequest request)
+    {
+        var path = string.IsNullOrWhiteSpace(request.BookId)
+            ? "/book-access"
+            : $"/books/{Uri.EscapeDataString(request.BookId)}/access";
+
+        var builder = new StringBuilder(path);
+        builder.Append('?');
+        AppendQuery(builder, "pageSize", request.PageSize.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        AppendOptionalQuery(builder, "continuationToken", request.ContinuationToken);
+        AppendOptionalQuery(builder, "principalId", request.PrincipalId);
+        AppendOptionalQuery(builder, "principalType", request.PrincipalType);
+        AppendOptionalQuery(builder, "accessLevel", request.AccessLevel);
+
+        return builder.ToString();
+    }
+
+    private static void AppendOptionalQuery(StringBuilder builder, string key, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return;
+        }
+
+        builder.Append('&');
+        AppendQuery(builder, key, value);
+    }
+
+    private static void AppendQuery(StringBuilder builder, string key, string value)
+    {
+        builder.Append(Uri.EscapeDataString(key));
+        builder.Append('=');
+        builder.Append(Uri.EscapeDataString(value));
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/BookAccess/Serialization/DefaultBookAccessResponseReader.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAccess/Serialization/DefaultBookAccessResponseReader.cs
@@ -1,0 +1,60 @@
+using System.Net.Http.Json;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Models.Common;
+
+namespace PublishingPlatform.SDK.Clients.BookAccess.Serialization;
+
+/// <summary>
+/// Reads and validates book access response payloads.
+/// </summary>
+internal sealed class DefaultBookAccessResponseReader : IBookAccessResponseReader
+{
+    /// <inheritdoc />
+    public async Task<BookAccessGrantResult> ReadGrantResultAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        var payload = await response.Content.ReadFromJsonAsync<BookAccessGrantResult>(ct).ConfigureAwait(false);
+        if (payload is null)
+        {
+            throw new BookValidationException("Book access grant payload was empty.");
+        }
+
+        return payload;
+    }
+
+    /// <inheritdoc />
+    public async Task<BookAccessRevokeResult> ReadRevokeResultAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        var payload = await response.Content.ReadFromJsonAsync<BookAccessRevokeResult>(ct).ConfigureAwait(false);
+        if (payload is null)
+        {
+            throw new BookValidationException("Book access revoke payload was empty.");
+        }
+
+        return payload;
+    }
+
+    /// <inheritdoc />
+    public async Task<BookAccessStatus> ReadStatusAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        var payload = await response.Content.ReadFromJsonAsync<BookAccessStatus>(ct).ConfigureAwait(false);
+        if (payload is null)
+        {
+            throw new BookValidationException("Book access status payload was empty.");
+        }
+
+        return payload;
+    }
+
+    /// <inheritdoc />
+    public async Task<PagedResult<BookAccessGrant>> ReadPagedGrantResultAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        var payload = await response.Content.ReadFromJsonAsync<PagedResult<BookAccessGrant>>(ct).ConfigureAwait(false);
+        if (payload is null)
+        {
+            throw new BookValidationException("Paged book access payload was empty.");
+        }
+
+        return payload;
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/BookAccess/Serialization/IBookAccessQueryStringBuilder.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAccess/Serialization/IBookAccessQueryStringBuilder.cs
@@ -1,0 +1,23 @@
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookAccess.Serialization;
+
+/// <summary>
+/// Builds querystring-based relative paths for book access operations.
+/// </summary>
+internal interface IBookAccessQueryStringBuilder
+{
+    /// <summary>
+    /// Builds a relative path for an access check operation.
+    /// </summary>
+    /// <param name="request">The check request.</param>
+    /// <returns>The transport relative path.</returns>
+    string BuildCheckPath(BookAccessCheckRequest request);
+
+    /// <summary>
+    /// Builds a relative path for access list operation.
+    /// </summary>
+    /// <param name="request">The list request.</param>
+    /// <returns>The transport relative path.</returns>
+    string BuildListPath(ListBookAccessRequest request);
+}

--- a/src/PublishingPlatform.SDK/Clients/BookAccess/Serialization/IBookAccessResponseReader.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAccess/Serialization/IBookAccessResponseReader.cs
@@ -1,0 +1,42 @@
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Models.Common;
+
+namespace PublishingPlatform.SDK.Clients.BookAccess.Serialization;
+
+/// <summary>
+/// Reads book access response payloads.
+/// </summary>
+internal interface IBookAccessResponseReader
+{
+    /// <summary>
+    /// Reads grant result payload.
+    /// </summary>
+    /// <param name="response">The HTTP response.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The grant result.</returns>
+    Task<BookAccessGrantResult> ReadGrantResultAsync(HttpResponseMessage response, CancellationToken ct);
+
+    /// <summary>
+    /// Reads revoke result payload.
+    /// </summary>
+    /// <param name="response">The HTTP response.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The revoke result.</returns>
+    Task<BookAccessRevokeResult> ReadRevokeResultAsync(HttpResponseMessage response, CancellationToken ct);
+
+    /// <summary>
+    /// Reads access status payload.
+    /// </summary>
+    /// <param name="response">The HTTP response.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The access status.</returns>
+    Task<BookAccessStatus> ReadStatusAsync(HttpResponseMessage response, CancellationToken ct);
+
+    /// <summary>
+    /// Reads paged list payload of grants.
+    /// </summary>
+    /// <param name="response">The HTTP response.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The paged list of grants.</returns>
+    Task<PagedResult<BookAccessGrant>> ReadPagedGrantResultAsync(HttpResponseMessage response, CancellationToken ct);
+}

--- a/src/PublishingPlatform.SDK/Clients/BookAccess/Validation/DefaultBookAccessRequestValidator.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAccess/Validation/DefaultBookAccessRequestValidator.cs
@@ -1,0 +1,115 @@
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookAccess.Validation;
+
+/// <summary>
+/// Enforces validation rules for book access requests.
+/// </summary>
+internal sealed class DefaultBookAccessRequestValidator : IBookAccessRequestValidator
+{
+    private static readonly HashSet<string> AllowedPrincipalTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "user",
+        "group",
+        "organization",
+    };
+
+    private static readonly HashSet<string> AllowedAccessLevels = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "read",
+        "write",
+        "owner",
+    };
+
+    /// <inheritdoc />
+    public void ValidateGrant(BookAccessGrantRequest request)
+    {
+        ValidateBookId(request.BookId);
+        ValidatePrincipalId(request.PrincipalId);
+        ValidateAccessLevel(request.AccessLevel);
+        ValidatePrincipalType(request.PrincipalType);
+
+        if (request.ExpiresAt.HasValue && request.ExpiresAt.Value <= DateTimeOffset.UtcNow)
+        {
+            throw new BookValidationException("ExpiresAt must be in the future when provided.");
+        }
+    }
+
+    /// <inheritdoc />
+    public void ValidateRevoke(BookAccessRevokeRequest request)
+    {
+        ValidateBookId(request.BookId);
+        ValidatePrincipalId(request.PrincipalId);
+        ValidatePrincipalType(request.PrincipalType);
+    }
+
+    /// <inheritdoc />
+    public void ValidateCheck(BookAccessCheckRequest request)
+    {
+        ValidateBookId(request.BookId);
+        ValidatePrincipalId(request.PrincipalId);
+        ValidatePrincipalType(request.PrincipalType);
+    }
+
+    /// <inheritdoc />
+    public void ValidateList(ListBookAccessRequest request)
+    {
+        if (request.PageSize < 1 || request.PageSize > 200)
+        {
+            throw new BookValidationException("PageSize must be between 1 and 200.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.PrincipalType))
+        {
+            ValidatePrincipalType(request.PrincipalType);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.AccessLevel))
+        {
+            ValidateAccessLevel(request.AccessLevel);
+        }
+    }
+
+    private static void ValidateBookId(string bookId)
+    {
+        if (string.IsNullOrWhiteSpace(bookId))
+        {
+            throw new BookValidationException("Book id is required.");
+        }
+    }
+
+    private static void ValidatePrincipalId(string principalId)
+    {
+        if (string.IsNullOrWhiteSpace(principalId))
+        {
+            throw new BookValidationException("PrincipalId is required.");
+        }
+    }
+
+    private static void ValidatePrincipalType(string principalType)
+    {
+        if (string.IsNullOrWhiteSpace(principalType))
+        {
+            throw new BookValidationException("PrincipalType is required.");
+        }
+
+        if (!AllowedPrincipalTypes.Contains(principalType))
+        {
+            throw new BookValidationException("PrincipalType must be one of: user, group, organization.");
+        }
+    }
+
+    private static void ValidateAccessLevel(string accessLevel)
+    {
+        if (string.IsNullOrWhiteSpace(accessLevel))
+        {
+            throw new BookValidationException("AccessLevel is required.");
+        }
+
+        if (!AllowedAccessLevels.Contains(accessLevel))
+        {
+            throw new BookValidationException("AccessLevel must be one of: read, write, owner.");
+        }
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/BookAccess/Validation/IBookAccessRequestValidator.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAccess/Validation/IBookAccessRequestValidator.cs
@@ -1,0 +1,33 @@
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookAccess.Validation;
+
+/// <summary>
+/// Defines validation rules for book access operations.
+/// </summary>
+internal interface IBookAccessRequestValidator
+{
+    /// <summary>
+    /// Validates grant request payload.
+    /// </summary>
+    /// <param name="request">The grant request.</param>
+    void ValidateGrant(BookAccessGrantRequest request);
+
+    /// <summary>
+    /// Validates revoke request payload.
+    /// </summary>
+    /// <param name="request">The revoke request.</param>
+    void ValidateRevoke(BookAccessRevokeRequest request);
+
+    /// <summary>
+    /// Validates check request payload.
+    /// </summary>
+    /// <param name="request">The check request.</param>
+    void ValidateCheck(BookAccessCheckRequest request);
+
+    /// <summary>
+    /// Validates list request payload.
+    /// </summary>
+    /// <param name="request">The list request.</param>
+    void ValidateList(ListBookAccessRequest request);
+}

--- a/src/PublishingPlatform.SDK/Clients/BookAccessClient.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAccessClient.cs
@@ -1,14 +1,137 @@
+using System.Diagnostics;
+using System.Net.Http.Json;
 using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Clients.BookAccess.Serialization;
+using PublishingPlatform.SDK.Clients.BookAccess.Validation;
+using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Transport;
+using PublishingPlatform.SDK.Internal;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Models.Common;
 
 namespace PublishingPlatform.SDK.Clients;
 
+/// <summary>
+/// Orchestrates book access and entitlement operations through the shared transport.
+/// </summary>
 public sealed class BookAccessClient : IBookAccessClient
 {
     private readonly ISharedHttpTransport _transport;
+    private readonly IBookAccessRequestValidator _validator;
+    private readonly IBookAccessQueryStringBuilder _queryStringBuilder;
+    private readonly IBookAccessResponseReader _responseReader;
 
     internal BookAccessClient(ISharedHttpTransport transport)
+        : this(
+            transport,
+            new DefaultBookAccessRequestValidator(),
+            new DefaultBookAccessQueryStringBuilder(),
+            new DefaultBookAccessResponseReader())
+    {
+    }
+
+    internal BookAccessClient(
+        ISharedHttpTransport transport,
+        IBookAccessRequestValidator validator,
+        IBookAccessQueryStringBuilder queryStringBuilder,
+        IBookAccessResponseReader responseReader)
     {
         _transport = transport;
+        _validator = validator;
+        _queryStringBuilder = queryStringBuilder;
+        _responseReader = responseReader;
+    }
+
+    /// <inheritdoc />
+    public async Task<BookAccessGrantResult> GrantAsync(
+        BookAccessGrantRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        Guards.NotNull(request, nameof(request));
+        _validator.ValidateGrant(request);
+
+        using var activity = StartActivity("BookAccess.Grant");
+        var content = JsonContent.Create(request);
+        var relativePath = $"/books/{Uri.EscapeDataString(request.BookId)}/access";
+        using var response = await _transport.SendAsync(
+            HttpMethod.Post,
+            relativePath,
+            content,
+            null,
+            "BookAccess.Grant",
+            cancellationToken).ConfigureAwait(false);
+
+        return await _responseReader.ReadGrantResultAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<BookAccessRevokeResult> RevokeAsync(
+        BookAccessRevokeRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        Guards.NotNull(request, nameof(request));
+        _validator.ValidateRevoke(request);
+
+        using var activity = StartActivity("BookAccess.Revoke");
+        var content = JsonContent.Create(request);
+        var relativePath = $"/books/{Uri.EscapeDataString(request.BookId)}/access/revoke";
+        using var response = await _transport.SendAsync(
+            HttpMethod.Post,
+            relativePath,
+            content,
+            null,
+            "BookAccess.Revoke",
+            cancellationToken).ConfigureAwait(false);
+
+        return await _responseReader.ReadRevokeResultAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<BookAccessStatus> CheckAsync(
+        BookAccessCheckRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        Guards.NotNull(request, nameof(request));
+        _validator.ValidateCheck(request);
+
+        using var activity = StartActivity("BookAccess.Check");
+        var relativePath = _queryStringBuilder.BuildCheckPath(request);
+        using var response = await _transport.SendAsync(
+            HttpMethod.Get,
+            relativePath,
+            null,
+            null,
+            "BookAccess.Check",
+            cancellationToken).ConfigureAwait(false);
+
+        return await _responseReader.ReadStatusAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<PagedResult<BookAccessGrant>> ListAsync(
+        ListBookAccessRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        Guards.NotNull(request, nameof(request));
+        _validator.ValidateList(request);
+
+        using var activity = StartActivity("BookAccess.List");
+        var relativePath = _queryStringBuilder.BuildListPath(request);
+        using var response = await _transport.SendAsync(
+            HttpMethod.Get,
+            relativePath,
+            null,
+            null,
+            "BookAccess.List",
+            cancellationToken).ConfigureAwait(false);
+
+        return await _responseReader.ReadPagedGrantResultAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static Activity? StartActivity(string operationName)
+    {
+        var activity = ActivitySourceProvider.ActivitySource.StartActivity(operationName, ActivityKind.Client);
+        activity?.SetTag("sdk.operation", operationName);
+        return activity;
     }
 }

--- a/src/PublishingPlatform.SDK/Models/BookAccessCheckRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/BookAccessCheckRequest.cs
@@ -1,9 +1,9 @@
 namespace PublishingPlatform.SDK.Models;
 
 /// <summary>
-/// Represents a request to revoke access from a book principal.
+/// Represents a request to check whether a principal can access a book.
 /// </summary>
-public sealed class BookAccessRevokeRequest
+public sealed class BookAccessCheckRequest
 {
     /// <summary>
     /// Gets or sets the book identifier.
@@ -11,17 +11,12 @@ public sealed class BookAccessRevokeRequest
     public string BookId { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the principal identifier losing access.
+    /// Gets or sets the principal identifier.
     /// </summary>
     public string PrincipalId { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the principal type losing access (for example user, group, organization).
+    /// Gets or sets the principal type (for example user, group, organization).
     /// </summary>
     public string PrincipalType { get; set; } = "user";
-
-    /// <summary>
-    /// Gets or sets an optional reason for auditability.
-    /// </summary>
-    public string? Reason { get; set; }
 }

--- a/src/PublishingPlatform.SDK/Models/BookAccessGrant.cs
+++ b/src/PublishingPlatform.SDK/Models/BookAccessGrant.cs
@@ -1,0 +1,52 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents an active or historical grant entry for book access.
+/// </summary>
+public sealed class BookAccessGrant
+{
+    /// <summary>
+    /// Gets or sets the grant identifier.
+    /// </summary>
+    public string GrantId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the book identifier.
+    /// </summary>
+    public string BookId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the principal identifier.
+    /// </summary>
+    public string PrincipalId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the principal type.
+    /// </summary>
+    public string PrincipalType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the granted access level.
+    /// </summary>
+    public string AccessLevel { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the optional reason for the grant.
+    /// </summary>
+    public string? Reason { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp when the grant was created.
+    /// </summary>
+    public DateTimeOffset GrantedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the actor who granted access.
+    /// </summary>
+    public string GrantedBy { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets optional grant expiration.
+    /// </summary>
+    public DateTimeOffset? ExpiresAt { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Models/BookAccessGrantRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/BookAccessGrantRequest.cs
@@ -16,6 +16,11 @@ public sealed class BookAccessGrantRequest
     public string PrincipalId { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the principal type receiving access (for example user, group, organization).
+    /// </summary>
+    public string PrincipalType { get; set; } = "user";
+
+    /// <summary>
     /// Gets or sets the access level to grant.
     /// </summary>
     public string AccessLevel { get; set; } = string.Empty;

--- a/src/PublishingPlatform.SDK/Models/BookAccessGrantResult.cs
+++ b/src/PublishingPlatform.SDK/Models/BookAccessGrantResult.cs
@@ -1,0 +1,42 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents the outcome of granting access to a book principal.
+/// </summary>
+public sealed class BookAccessGrantResult
+{
+    /// <summary>
+    /// Gets or sets the created or updated grant identifier.
+    /// </summary>
+    public string GrantId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the related book identifier.
+    /// </summary>
+    public string BookId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the principal identifier.
+    /// </summary>
+    public string PrincipalId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the principal type.
+    /// </summary>
+    public string PrincipalType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the granted access level.
+    /// </summary>
+    public string AccessLevel { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the grant was newly created.
+    /// </summary>
+    public bool Created { get; set; }
+
+    /// <summary>
+    /// Gets or sets optional grant expiration.
+    /// </summary>
+    public DateTimeOffset? ExpiresAt { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Models/BookAccessRevokeResult.cs
+++ b/src/PublishingPlatform.SDK/Models/BookAccessRevokeResult.cs
@@ -1,0 +1,37 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents the outcome of revoking access from a book principal.
+/// </summary>
+public sealed class BookAccessRevokeResult
+{
+    /// <summary>
+    /// Gets or sets the related book identifier.
+    /// </summary>
+    public string BookId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the principal identifier.
+    /// </summary>
+    public string PrincipalId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the principal type.
+    /// </summary>
+    public string PrincipalType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether an active grant was revoked.
+    /// </summary>
+    public bool Revoked { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp when revocation occurred.
+    /// </summary>
+    public DateTimeOffset RevokedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets optional revoke reason.
+    /// </summary>
+    public string? Reason { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Models/BookAccessStatus.cs
+++ b/src/PublishingPlatform.SDK/Models/BookAccessStatus.cs
@@ -1,0 +1,42 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents effective access state for a principal and book.
+/// </summary>
+public sealed class BookAccessStatus
+{
+    /// <summary>
+    /// Gets or sets the related book identifier.
+    /// </summary>
+    public string BookId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the principal identifier.
+    /// </summary>
+    public string PrincipalId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the principal type.
+    /// </summary>
+    public string PrincipalType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether access is currently allowed.
+    /// </summary>
+    public bool HasAccess { get; set; }
+
+    /// <summary>
+    /// Gets or sets the effective access level when access is present.
+    /// </summary>
+    public string? AccessLevel { get; set; }
+
+    /// <summary>
+    /// Gets or sets why access is allowed or denied.
+    /// </summary>
+    public string? Reason { get; set; }
+
+    /// <summary>
+    /// Gets or sets optional expiration of current effective access.
+    /// </summary>
+    public DateTimeOffset? ExpiresAt { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Models/ListBookAccessRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/ListBookAccessRequest.cs
@@ -1,0 +1,37 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents filtering and paging criteria for book access queries.
+/// </summary>
+public sealed class ListBookAccessRequest
+{
+    /// <summary>
+    /// Gets or sets an optional book identifier. When omitted, listing is global.
+    /// </summary>
+    public string? BookId { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional principal identifier filter.
+    /// </summary>
+    public string? PrincipalId { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional principal type filter.
+    /// </summary>
+    public string? PrincipalType { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional access level filter.
+    /// </summary>
+    public string? AccessLevel { get; set; }
+
+    /// <summary>
+    /// Gets or sets the page size for the current read.
+    /// </summary>
+    public int PageSize { get; set; } = 50;
+
+    /// <summary>
+    /// Gets or sets continuation token for paged iteration.
+    /// </summary>
+    public string? ContinuationToken { get; set; }
+}

--- a/tests/PublishingPlatform.SDK.Tests/BookAccess/BookAccessClientTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/BookAccess/BookAccessClientTests.cs
@@ -1,0 +1,314 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Infrastructure.Errors;
+using PublishingPlatform.SDK.Infrastructure.Transport;
+using PublishingPlatform.SDK.Internal.Resilience;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Models.Common;
+
+namespace PublishingPlatform.SDK.Tests.BookAccess;
+
+public sealed class BookAccessClientTests
+{
+    [Fact]
+    public async Task GrantAsync_SendsPostWithExpectedRouteAndCancellation()
+    {
+        var token = new CancellationTokenSource().Token;
+        var request = new BookAccessGrantRequest
+        {
+            BookId = "book-1",
+            PrincipalId = "user-1",
+            PrincipalType = "user",
+            AccessLevel = "read",
+            ExpiresAt = DateTimeOffset.UtcNow.AddDays(7),
+        };
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+            HttpMethod.Post,
+            "/books/book-1/access",
+            Arg.Any<HttpContent>(),
+            null,
+            "BookAccess.Grant",
+            token).Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new BookAccessGrantResult
+                {
+                    GrantId = "grant-1",
+                    BookId = request.BookId,
+                    PrincipalId = request.PrincipalId,
+                    PrincipalType = request.PrincipalType,
+                    AccessLevel = request.AccessLevel,
+                    Created = true,
+                }),
+            }));
+        var sut = new BookAccessClient(transport);
+
+        var result = await sut.GrantAsync(request, token);
+
+        result.GrantId.Should().Be("grant-1");
+        await transport.Received(1).SendAsync(
+            HttpMethod.Post,
+            "/books/book-1/access",
+            Arg.Any<HttpContent>(),
+            null,
+            "BookAccess.Grant",
+            token);
+    }
+
+    [Fact]
+    public async Task RevokeAsync_SendsPostWithExpectedRoute()
+    {
+        var request = new BookAccessRevokeRequest
+        {
+            BookId = "book-2",
+            PrincipalId = "user-2",
+            PrincipalType = "user",
+            Reason = "refund",
+        };
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+            HttpMethod.Post,
+            "/books/book-2/access/revoke",
+            Arg.Any<HttpContent>(),
+            null,
+            "BookAccess.Revoke",
+            Arg.Any<CancellationToken>()).Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new BookAccessRevokeResult
+                {
+                    BookId = request.BookId,
+                    PrincipalId = request.PrincipalId,
+                    PrincipalType = request.PrincipalType,
+                    Revoked = true,
+                }),
+            }));
+        var sut = new BookAccessClient(transport);
+
+        var result = await sut.RevokeAsync(request);
+
+        result.Revoked.Should().BeTrue();
+        await transport.Received(1).SendAsync(
+            HttpMethod.Post,
+            "/books/book-2/access/revoke",
+            Arg.Any<HttpContent>(),
+            null,
+            "BookAccess.Revoke",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CheckAsync_BuildsDeterministicQuery()
+    {
+        var request = new BookAccessCheckRequest
+        {
+            BookId = "book 3",
+            PrincipalId = "user+3",
+            PrincipalType = "user",
+        };
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+            HttpMethod.Get,
+            "/books/book%203/access/check?principalId=user%2B3&principalType=user",
+            null,
+            null,
+            "BookAccess.Check",
+            Arg.Any<CancellationToken>()).Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new BookAccessStatus
+                {
+                    BookId = request.BookId,
+                    PrincipalId = request.PrincipalId,
+                    PrincipalType = request.PrincipalType,
+                    HasAccess = true,
+                    AccessLevel = "read",
+                }),
+            }));
+        var sut = new BookAccessClient(transport);
+
+        _ = await sut.CheckAsync(request);
+
+        await transport.Received(1).SendAsync(
+            HttpMethod.Get,
+            "/books/book%203/access/check?principalId=user%2B3&principalType=user",
+            null,
+            null,
+            "BookAccess.Check",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListAsync_UsesPerBookRoute_WhenBookIdIsProvided()
+    {
+        var request = new ListBookAccessRequest
+        {
+            BookId = "book-4",
+            PrincipalType = "user",
+            PageSize = 20,
+            ContinuationToken = "ct-1",
+        };
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+            HttpMethod.Get,
+            "/books/book-4/access?pageSize=20&continuationToken=ct-1&principalType=user",
+            null,
+            null,
+            "BookAccess.List",
+            Arg.Any<CancellationToken>()).Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new PagedResult<BookAccessGrant>
+                {
+                    Items = Array.Empty<BookAccessGrant>(),
+                }),
+            }));
+        var sut = new BookAccessClient(transport);
+
+        _ = await sut.ListAsync(request);
+
+        await transport.Received(1).SendAsync(
+            HttpMethod.Get,
+            "/books/book-4/access?pageSize=20&continuationToken=ct-1&principalType=user",
+            null,
+            null,
+            "BookAccess.List",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListAsync_UsesGlobalRoute_WhenBookIdIsMissing()
+    {
+        var request = new ListBookAccessRequest
+        {
+            PrincipalId = "org-1",
+            PrincipalType = "organization",
+            AccessLevel = "read",
+            PageSize = 10,
+        };
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+            HttpMethod.Get,
+            "/book-access?pageSize=10&principalId=org-1&principalType=organization&accessLevel=read",
+            null,
+            null,
+            "BookAccess.List",
+            Arg.Any<CancellationToken>()).Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new PagedResult<BookAccessGrant>
+                {
+                    Items = Array.Empty<BookAccessGrant>(),
+                }),
+            }));
+        var sut = new BookAccessClient(transport);
+
+        _ = await sut.ListAsync(request);
+
+        await transport.Received(1).SendAsync(
+            HttpMethod.Get,
+            "/book-access?pageSize=10&principalId=org-1&principalType=organization&accessLevel=read",
+            null,
+            null,
+            "BookAccess.List",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GrantAsync_ThrowsBookValidationException_ForInvalidPrincipalType()
+    {
+        var sut = new BookAccessClient(Substitute.For<ISharedHttpTransport>());
+
+        var act = async () => await sut.GrantAsync(new BookAccessGrantRequest
+        {
+            BookId = "book-1",
+            PrincipalId = "principal-1",
+            PrincipalType = "tenant",
+            AccessLevel = "read",
+            ExpiresAt = DateTimeOffset.UtcNow.AddDays(1),
+        });
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("PrincipalType must be one of");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(201)]
+    public async Task ListAsync_ThrowsBookValidationException_ForInvalidPageSize(int pageSize)
+    {
+        var sut = new BookAccessClient(Substitute.For<ISharedHttpTransport>());
+
+        var act = async () => await sut.ListAsync(new ListBookAccessRequest
+        {
+            PageSize = pageSize,
+        });
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("PageSize must be between 1 and 200");
+    }
+
+    [Fact]
+    public async Task CheckAsync_ThrowsBookValidationException_WhenPayloadIsNull()
+    {
+        using var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, "application/json"),
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.test") };
+        var transport = new SharedHttpTransport(client, new NoOpPublishingPlatformResiliencePipeline(), new FixedCorrelationIdProvider(), new DefaultPublishingPlatformErrorMapper());
+        var sut = new BookAccessClient(transport);
+
+        var act = async () => await sut.CheckAsync(new BookAccessCheckRequest
+        {
+            BookId = "book-null",
+            PrincipalId = "user-null",
+            PrincipalType = "user",
+        });
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Book access status payload was empty");
+    }
+
+    [Fact]
+    public async Task ListAsync_ThrowsBookValidationException_WhenPagedPayloadIsNull()
+    {
+        using var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, "application/json"),
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.test") };
+        var transport = new SharedHttpTransport(client, new NoOpPublishingPlatformResiliencePipeline(), new FixedCorrelationIdProvider(), new DefaultPublishingPlatformErrorMapper());
+        var sut = new BookAccessClient(transport);
+
+        var act = async () => await sut.ListAsync(new ListBookAccessRequest
+        {
+            PageSize = 10,
+        });
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Paged book access payload was empty");
+    }
+
+    private sealed class SingleResponseHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+
+        public SingleResponseHandler(HttpResponseMessage response)
+        {
+            _response = response;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_response);
+        }
+    }
+
+    private sealed class FixedCorrelationIdProvider : ICorrelationIdProvider
+    {
+        public string Create()
+        {
+            return Guid.NewGuid().ToString("N");
+        }
+    }
+}

--- a/tests/PublishingPlatform.SDK.Tests/Models/RequestModelContractsTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Models/RequestModelContractsTests.cs
@@ -12,6 +12,7 @@ public sealed class RequestModelContractsTests
 
         request.BookId.Should().BeEmpty();
         request.PrincipalId.Should().BeEmpty();
+        request.PrincipalType.Should().Be("user");
         request.AccessLevel.Should().BeEmpty();
         request.ExpiresAt.Should().BeNull();
         request.IdempotencyKey.Should().BeNull();
@@ -96,7 +97,28 @@ public sealed class RequestModelContractsTests
 
         request.BookId.Should().BeEmpty();
         request.PrincipalId.Should().BeEmpty();
+        request.PrincipalType.Should().Be("user");
         request.Reason.Should().BeNull();
+    }
+
+    [Fact]
+    public void BookAccessCheckRequest_Defaults_AreSafe()
+    {
+        var request = new BookAccessCheckRequest();
+
+        request.BookId.Should().BeEmpty();
+        request.PrincipalId.Should().BeEmpty();
+        request.PrincipalType.Should().Be("user");
+    }
+
+    [Fact]
+    public void ListBookAccessRequest_Defaults_AreSafe()
+    {
+        var request = new ListBookAccessRequest();
+
+        request.BookId.Should().BeNull();
+        request.PageSize.Should().Be(50);
+        request.ContinuationToken.Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
# Summary

What changed:
- Expanded `IBookAccessClient` with public operations:
  - `GrantAsync(BookAccessGrantRequest, CancellationToken)`
  - `RevokeAsync(BookAccessRevokeRequest, CancellationToken)`
  - `CheckAsync(BookAccessCheckRequest, CancellationToken)`
  - `ListAsync(ListBookAccessRequest, CancellationToken)`
- Implemented `BookAccessClient` as orchestration-only using shared transport with operation-level diagnostics:
  - `POST /books/{bookId}/access`
  - `POST /books/{bookId}/access/revoke`
  - `GET /books/{bookId}/access/check`
  - `GET /books/{bookId}/access` (per-book listing)
  - `GET /book-access` (global listing)
- Added BookAccess collaborators to keep responsibilities split:
  - validation (`DefaultBookAccessRequestValidator`)
  - query composition (`DefaultBookAccessQueryStringBuilder`)
  - response reading (`DefaultBookAccessResponseReader`)
- Added new public models:
  - `BookAccessCheckRequest`
  - `ListBookAccessRequest`
  - `BookAccessGrant`
  - `BookAccessGrantResult`
  - `BookAccessRevokeResult`
  - `BookAccessStatus`
- Extended existing request models with `PrincipalType` for consistent grant/revoke/check semantics.
- Updated consumer docs (`README.md`, `docs/architecture.md`) to reflect active `BookAccess` operations.

API impact:
- `IBookAccessClient` changed from placeholder to functional contract (new methods).
- New public BookAccess request/response models added.
- Existing `BookAccessGrantRequest` and `BookAccessRevokeRequest` now include `PrincipalType` with default `user`.

# Validation

- [x] `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal`
- [x] Added/updated tests for BookAccess happy paths, guards/validation, route/query correctness, null payload handling, and global vs per-book list routing

Test result evidence:
- Passed: 162
- Failed: 0
- Skipped: 0

# Release Please Override (Required for releasable changes)

# Manual NuGet Publish

1. Confirm `Directory.Build.props` version equals the intended release version.
2. Create matching tag `v<version>` on the exact commit to publish.
3. Run the `Publish NuGet` workflow manually with the same tag.
4. Verify the published package version appears on NuGet.
