### PR TITLE
RPS-53 fix: implement book analytics summary client operation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.12</Version>
+    <Version>0.0.13</Version>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Runnable scripts are available in:
 - `examples/BasicUsage/DiInitializationExample.csx`
 - `examples/BookPublishing/BookPublishingExample.csx`
 - `examples/BookDistribution/BookDistributionExample.csx`
+- `examples/BookAnalytics/BookAnalyticsExample.csx`
 
 ## Client modules: available properties and use cases
 
@@ -211,8 +212,9 @@ Module accessor for analytics and reporting workflows.
 Current status:
 
 - Property is available on the root client.
-- Interface is currently a placeholder (no public operations yet in this SDK version).
-- Strongly typed request models are available for upcoming analytics operations (`GetBookAnalyticsRequest`).
+- `GetSummaryAsync(GetBookAnalyticsRequest, CancellationToken)` is available for aggregate analytics retrieval.
+- Current request-to-query mapping sends `bookId`, `from`, and `to` to `/book-analytics/summary`.
+- `Granularity` and `IncludeUniqueReaders` exist on `GetBookAnalyticsRequest` as future-facing fields and are currently not sent until the backend contract expands.
 
 Typical use cases once expanded:
 

--- a/examples/BookAnalytics/BookAnalyticsExample.csx
+++ b/examples/BookAnalytics/BookAnalyticsExample.csx
@@ -1,0 +1,28 @@
+//r "nuget: PublishingPlatform.SDK"
+
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Options;
+
+var client = PublishingPlatformClientBuilder.Create(new PublishingPlatformClientOptions
+{
+    BaseUrl = "https://api.books.example",
+    ApiKey = "your-api-key",
+}).Build();
+
+var from = DateTimeOffset.UtcNow.AddDays(-7);
+var to = DateTimeOffset.UtcNow;
+
+var summary = await client.BookAnalytics.GetSummaryAsync(new GetBookAnalyticsRequest
+{
+    BookId = "book-123",
+    From = from,
+    To = to,
+    Granularity = "day",
+    IncludeUniqueReaders = true,
+});
+
+Console.WriteLine($"Summary window: {from:O} -> {to:O}");
+Console.WriteLine($"Total views: {summary.TotalViews}");
+Console.WriteLine($"Total downloads: {summary.TotalDownloads}");
+Console.WriteLine($"Active readers: {summary.ActiveReaders}");

--- a/examples/BookAnalytics/README.md
+++ b/examples/BookAnalytics/README.md
@@ -1,0 +1,17 @@
+# BookAnalytics Example
+
+This example demonstrates aggregate analytics retrieval through `IBookAnalyticsClient`:
+
+- `GetSummaryAsync(...)`
+
+It maps request values to:
+
+- `GET /book-analytics/summary?bookId=...&from=...&to=...`
+
+Notes:
+
+- `Granularity` and `IncludeUniqueReaders` are currently future-facing fields in the SDK model and are not sent to the current backend summary endpoint.
+
+Run:
+
+- `examples/BookAnalytics/BookAnalyticsExample.csx`

--- a/src/PublishingPlatform.SDK/Abstractions/IBookAnalyticsClient.cs
+++ b/src/PublishingPlatform.SDK/Abstractions/IBookAnalyticsClient.cs
@@ -1,5 +1,19 @@
-﻿namespace PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Models;
 
+namespace PublishingPlatform.SDK.Abstractions;
+
+/// <summary>
+/// Provides aggregate analytics operations for books.
+/// </summary>
 public interface IBookAnalyticsClient
 {
+    /// <summary>
+    /// Gets aggregate analytics summary metrics for a book within a date range.
+    /// </summary>
+    /// <param name="request">The analytics summary request criteria.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The aggregate analytics summary for the requested book and range.</returns>
+    Task<AnalyticsSummary> GetSummaryAsync(
+        GetBookAnalyticsRequest request,
+        CancellationToken cancellationToken = default);
 }

--- a/src/PublishingPlatform.SDK/Clients/BookAnalytics/Serialization/DefaultBookAnalyticsQueryStringBuilder.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAnalytics/Serialization/DefaultBookAnalyticsQueryStringBuilder.cs
@@ -1,0 +1,31 @@
+using System.Globalization;
+using System.Text;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookAnalytics.Serialization;
+
+/// <summary>
+/// Builds deterministic query paths for analytics summary requests.
+/// </summary>
+internal sealed class DefaultBookAnalyticsQueryStringBuilder : IBookAnalyticsQueryStringBuilder
+{
+    /// <inheritdoc />
+    public string BuildSummaryPath(GetBookAnalyticsRequest request)
+    {
+        var builder = new StringBuilder("/book-analytics/summary?");
+        AppendQuery(builder, "bookId", request.BookId);
+        builder.Append('&');
+        AppendQuery(builder, "from", request.From!.Value.ToString("O", CultureInfo.InvariantCulture));
+        builder.Append('&');
+        AppendQuery(builder, "to", request.To!.Value.ToString("O", CultureInfo.InvariantCulture));
+
+        return builder.ToString();
+    }
+
+    private static void AppendQuery(StringBuilder builder, string key, string value)
+    {
+        builder.Append(Uri.EscapeDataString(key));
+        builder.Append('=');
+        builder.Append(Uri.EscapeDataString(value));
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/BookAnalytics/Serialization/DefaultBookAnalyticsResponseReader.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAnalytics/Serialization/DefaultBookAnalyticsResponseReader.cs
@@ -1,0 +1,23 @@
+using System.Net.Http.Json;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookAnalytics.Serialization;
+
+/// <summary>
+/// Reads and validates analytics summary response payloads.
+/// </summary>
+internal sealed class DefaultBookAnalyticsResponseReader : IBookAnalyticsResponseReader
+{
+    /// <inheritdoc />
+    public async Task<AnalyticsSummary> ReadSummaryAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        var payload = await response.Content.ReadFromJsonAsync<AnalyticsSummary>(ct).ConfigureAwait(false);
+        if (payload is null)
+        {
+            throw new BookValidationException("Book analytics summary payload was empty.");
+        }
+
+        return payload;
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/BookAnalytics/Serialization/IBookAnalyticsQueryStringBuilder.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAnalytics/Serialization/IBookAnalyticsQueryStringBuilder.cs
@@ -1,0 +1,16 @@
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookAnalytics.Serialization;
+
+/// <summary>
+/// Builds querystring-based relative paths for analytics operations.
+/// </summary>
+internal interface IBookAnalyticsQueryStringBuilder
+{
+    /// <summary>
+    /// Builds a relative path for analytics summary retrieval.
+    /// </summary>
+    /// <param name="request">The analytics request.</param>
+    /// <returns>The transport relative path.</returns>
+    string BuildSummaryPath(GetBookAnalyticsRequest request);
+}

--- a/src/PublishingPlatform.SDK/Clients/BookAnalytics/Serialization/IBookAnalyticsResponseReader.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAnalytics/Serialization/IBookAnalyticsResponseReader.cs
@@ -1,0 +1,17 @@
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookAnalytics.Serialization;
+
+/// <summary>
+/// Reads analytics response payloads.
+/// </summary>
+internal interface IBookAnalyticsResponseReader
+{
+    /// <summary>
+    /// Reads analytics summary payload.
+    /// </summary>
+    /// <param name="response">The HTTP response.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The analytics summary.</returns>
+    Task<AnalyticsSummary> ReadSummaryAsync(HttpResponseMessage response, CancellationToken ct);
+}

--- a/src/PublishingPlatform.SDK/Clients/BookAnalytics/Validation/DefaultBookAnalyticsRequestValidator.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAnalytics/Validation/DefaultBookAnalyticsRequestValidator.cs
@@ -1,0 +1,34 @@
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookAnalytics.Validation;
+
+/// <summary>
+/// Enforces input validation rules for analytics summary requests.
+/// </summary>
+internal sealed class DefaultBookAnalyticsRequestValidator : IBookAnalyticsRequestValidator
+{
+    /// <inheritdoc />
+    public void ValidateGetSummary(GetBookAnalyticsRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.BookId))
+        {
+            throw new BookValidationException("Book id is required.");
+        }
+
+        if (!request.From.HasValue)
+        {
+            throw new BookValidationException("From is required.");
+        }
+
+        if (!request.To.HasValue)
+        {
+            throw new BookValidationException("To is required.");
+        }
+
+        if (request.From.Value > request.To.Value)
+        {
+            throw new BookValidationException("From must be less than or equal to To.");
+        }
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/BookAnalytics/Validation/IBookAnalyticsRequestValidator.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAnalytics/Validation/IBookAnalyticsRequestValidator.cs
@@ -1,0 +1,15 @@
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookAnalytics.Validation;
+
+/// <summary>
+/// Defines validation rules for book analytics operations.
+/// </summary>
+internal interface IBookAnalyticsRequestValidator
+{
+    /// <summary>
+    /// Validates analytics summary request payload.
+    /// </summary>
+    /// <param name="request">The summary request.</param>
+    void ValidateGetSummary(GetBookAnalyticsRequest request);
+}

--- a/src/PublishingPlatform.SDK/Clients/BookAnalyticsClient.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAnalyticsClient.cs
@@ -1,14 +1,70 @@
+using System.Diagnostics;
 using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Clients.BookAnalytics.Serialization;
+using PublishingPlatform.SDK.Clients.BookAnalytics.Validation;
+using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Transport;
+using PublishingPlatform.SDK.Internal;
+using PublishingPlatform.SDK.Models;
 
 namespace PublishingPlatform.SDK.Clients;
 
+/// <summary>
+/// Orchestrates book analytics operations through the shared transport.
+/// </summary>
 public sealed class BookAnalyticsClient : IBookAnalyticsClient
 {
     private readonly ISharedHttpTransport _transport;
+    private readonly IBookAnalyticsRequestValidator _validator;
+    private readonly IBookAnalyticsQueryStringBuilder _queryStringBuilder;
+    private readonly IBookAnalyticsResponseReader _responseReader;
 
     internal BookAnalyticsClient(ISharedHttpTransport transport)
+        : this(
+            transport,
+            new DefaultBookAnalyticsRequestValidator(),
+            new DefaultBookAnalyticsQueryStringBuilder(),
+            new DefaultBookAnalyticsResponseReader())
+    {
+    }
+
+    internal BookAnalyticsClient(
+        ISharedHttpTransport transport,
+        IBookAnalyticsRequestValidator validator,
+        IBookAnalyticsQueryStringBuilder queryStringBuilder,
+        IBookAnalyticsResponseReader responseReader)
     {
         _transport = transport;
+        _validator = validator;
+        _queryStringBuilder = queryStringBuilder;
+        _responseReader = responseReader;
+    }
+
+    /// <inheritdoc />
+    public async Task<AnalyticsSummary> GetSummaryAsync(
+        GetBookAnalyticsRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        Guards.NotNull(request, nameof(request));
+        _validator.ValidateGetSummary(request);
+
+        using var activity = StartActivity("BookAnalytics.GetSummary");
+        var relativePath = _queryStringBuilder.BuildSummaryPath(request);
+        using var response = await _transport.SendAsync(
+            HttpMethod.Get,
+            relativePath,
+            null,
+            null,
+            "BookAnalytics.GetSummary",
+            cancellationToken).ConfigureAwait(false);
+
+        return await _responseReader.ReadSummaryAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static Activity? StartActivity(string operationName)
+    {
+        var activity = ActivitySourceProvider.ActivitySource.StartActivity(operationName, ActivityKind.Client);
+        activity?.SetTag("sdk.operation", operationName);
+        return activity;
     }
 }

--- a/src/PublishingPlatform.SDK/Models/GetBookAnalyticsRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/GetBookAnalyticsRequest.cs
@@ -22,11 +22,13 @@ public sealed class GetBookAnalyticsRequest
 
     /// <summary>
     /// Gets or sets the aggregation granularity (for example, day/week/month).
+    /// Current analytics summary endpoint does not consume this value yet; this field is future-facing.
     /// </summary>
     public string Granularity { get; set; } = "day";
 
     /// <summary>
     /// Gets or sets a value indicating whether unique reader count is requested.
+    /// Current analytics summary endpoint does not consume this value yet; this field is future-facing.
     /// </summary>
     public bool IncludeUniqueReaders { get; set; } = true;
 }

--- a/tests/PublishingPlatform.SDK.Tests/BookAnalytics/BookAnalyticsClientTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/BookAnalytics/BookAnalyticsClientTests.cs
@@ -2,7 +2,6 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text;
 using Bogus;
-using PublishingPlatform.SDK.Abstractions;
 using PublishingPlatform.SDK.Clients;
 using PublishingPlatform.SDK.Exceptions;
 using PublishingPlatform.SDK.Infrastructure.Transport;
@@ -46,7 +45,7 @@ public sealed class BookAnalyticsClientTests
                     ActiveReaders = 18,
                 }),
             }));
-        IBookAnalyticsClient sut = new BookAnalyticsClient(transport);
+        BookAnalyticsClient sut = new BookAnalyticsClient(transport);
 
         var result = await sut.GetSummaryAsync(request, token);
 
@@ -66,7 +65,7 @@ public sealed class BookAnalyticsClientTests
     public async Task GetSummaryAsync_ThrowsArgumentNullException_ForNullRequest()
     {
         var transport = Substitute.For<ISharedHttpTransport>();
-        IBookAnalyticsClient sut = new BookAnalyticsClient(transport);
+        BookAnalyticsClient sut = new BookAnalyticsClient(transport);
 
         var act = async () => await sut.GetSummaryAsync(null!);
 
@@ -78,7 +77,7 @@ public sealed class BookAnalyticsClientTests
     public async Task GetSummaryAsync_ThrowsBookValidationException_ForMissingRequiredFields()
     {
         var transport = Substitute.For<ISharedHttpTransport>();
-        IBookAnalyticsClient sut = new BookAnalyticsClient(transport);
+        BookAnalyticsClient sut = new BookAnalyticsClient(transport);
         var request = new GetBookAnalyticsRequest
         {
             BookId = "book-1",
@@ -97,7 +96,7 @@ public sealed class BookAnalyticsClientTests
     public async Task GetSummaryAsync_ThrowsBookValidationException_ForMissingBookId()
     {
         var transport = Substitute.For<ISharedHttpTransport>();
-        IBookAnalyticsClient sut = new BookAnalyticsClient(transport);
+        BookAnalyticsClient sut = new BookAnalyticsClient(transport);
         var request = new GetBookAnalyticsRequest
         {
             BookId = " ",
@@ -116,7 +115,7 @@ public sealed class BookAnalyticsClientTests
     public async Task GetSummaryAsync_ThrowsBookValidationException_ForMissingTo()
     {
         var transport = Substitute.For<ISharedHttpTransport>();
-        IBookAnalyticsClient sut = new BookAnalyticsClient(transport);
+        BookAnalyticsClient sut = new BookAnalyticsClient(transport);
         var request = new GetBookAnalyticsRequest
         {
             BookId = "book-1",
@@ -135,7 +134,7 @@ public sealed class BookAnalyticsClientTests
     public async Task GetSummaryAsync_ThrowsBookValidationException_ForInvalidRange()
     {
         var transport = Substitute.For<ISharedHttpTransport>();
-        IBookAnalyticsClient sut = new BookAnalyticsClient(transport);
+        BookAnalyticsClient sut = new BookAnalyticsClient(transport);
         var request = new GetBookAnalyticsRequest
         {
             BookId = "book-1",
@@ -164,7 +163,7 @@ public sealed class BookAnalyticsClientTests
             {
                 Content = new StringContent("null", Encoding.UTF8, "application/json"),
             }));
-        IBookAnalyticsClient sut = new BookAnalyticsClient(transport);
+        BookAnalyticsClient sut = new BookAnalyticsClient(transport);
         var request = new GetBookAnalyticsRequest
         {
             BookId = "book-null",

--- a/tests/PublishingPlatform.SDK.Tests/BookAnalytics/BookAnalyticsClientTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/BookAnalytics/BookAnalyticsClientTests.cs
@@ -1,0 +1,185 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using Bogus;
+using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Infrastructure.Transport;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Tests.BookAnalytics;
+
+public sealed class BookAnalyticsClientTests
+{
+    [Fact]
+    public async Task GetSummaryAsync_SendsGetWithExpectedRouteAndCancellation()
+    {
+        Randomizer.Seed = new Random(53);
+        var faker = new Faker();
+        var token = new CancellationTokenSource().Token;
+        var from = new DateTimeOffset(2026, 5, 1, 10, 30, 0, TimeSpan.FromHours(2));
+        var to = new DateTimeOffset(2026, 5, 6, 9, 15, 0, TimeSpan.FromHours(2));
+        var bookId = $"book {faker.Random.Number(10, 99)}+{faker.Random.Number(100, 999)}";
+        var request = new GetBookAnalyticsRequest
+        {
+            BookId = bookId,
+            From = from,
+            To = to,
+            Granularity = "week",
+            IncludeUniqueReaders = false,
+        };
+        var expectedPath = BuildExpectedPath(bookId, from, to);
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+            HttpMethod.Get,
+            expectedPath,
+            null,
+            null,
+            "BookAnalytics.GetSummary",
+            token).Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new AnalyticsSummary
+                {
+                    TotalViews = 120,
+                    TotalDownloads = 35,
+                    ActiveReaders = 18,
+                }),
+            }));
+        IBookAnalyticsClient sut = new BookAnalyticsClient(transport);
+
+        var result = await sut.GetSummaryAsync(request, token);
+
+        result.TotalViews.Should().Be(120);
+        result.TotalDownloads.Should().Be(35);
+        result.ActiveReaders.Should().Be(18);
+        await transport.Received(1).SendAsync(
+            HttpMethod.Get,
+            expectedPath,
+            null,
+            null,
+            "BookAnalytics.GetSummary",
+            token);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_ThrowsArgumentNullException_ForNullRequest()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        IBookAnalyticsClient sut = new BookAnalyticsClient(transport);
+
+        var act = async () => await sut.GetSummaryAsync(null!);
+
+        _ = await act.Should().ThrowAsync<ArgumentNullException>();
+        await transport.DidNotReceiveWithAnyArgs().SendAsync(default!, default!, default, default, default!, default);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_ThrowsBookValidationException_ForMissingRequiredFields()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        IBookAnalyticsClient sut = new BookAnalyticsClient(transport);
+        var request = new GetBookAnalyticsRequest
+        {
+            BookId = "book-1",
+            From = null,
+            To = DateTimeOffset.UtcNow,
+        };
+
+        var act = async () => await sut.GetSummaryAsync(request);
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("From is required");
+        await transport.DidNotReceiveWithAnyArgs().SendAsync(default!, default!, default, default, default!, default);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_ThrowsBookValidationException_ForMissingBookId()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        IBookAnalyticsClient sut = new BookAnalyticsClient(transport);
+        var request = new GetBookAnalyticsRequest
+        {
+            BookId = " ",
+            From = DateTimeOffset.UtcNow.AddDays(-1),
+            To = DateTimeOffset.UtcNow,
+        };
+
+        var act = async () => await sut.GetSummaryAsync(request);
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Book id is required");
+        await transport.DidNotReceiveWithAnyArgs().SendAsync(default!, default!, default, default, default!, default);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_ThrowsBookValidationException_ForMissingTo()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        IBookAnalyticsClient sut = new BookAnalyticsClient(transport);
+        var request = new GetBookAnalyticsRequest
+        {
+            BookId = "book-1",
+            From = DateTimeOffset.UtcNow.AddDays(-1),
+            To = null,
+        };
+
+        var act = async () => await sut.GetSummaryAsync(request);
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("To is required");
+        await transport.DidNotReceiveWithAnyArgs().SendAsync(default!, default!, default, default, default!, default);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_ThrowsBookValidationException_ForInvalidRange()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        IBookAnalyticsClient sut = new BookAnalyticsClient(transport);
+        var request = new GetBookAnalyticsRequest
+        {
+            BookId = "book-1",
+            From = DateTimeOffset.UtcNow,
+            To = DateTimeOffset.UtcNow.AddDays(-2),
+        };
+
+        var act = async () => await sut.GetSummaryAsync(request);
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("From must be less than or equal to To");
+        await transport.DidNotReceiveWithAnyArgs().SendAsync(default!, default!, default, default, default!, default);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_ThrowsBookValidationException_WhenPayloadIsNull()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+            HttpMethod.Get,
+            Arg.Any<string>(),
+            null,
+            null,
+            "BookAnalytics.GetSummary",
+            Arg.Any<CancellationToken>()).Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("null", Encoding.UTF8, "application/json"),
+            }));
+        IBookAnalyticsClient sut = new BookAnalyticsClient(transport);
+        var request = new GetBookAnalyticsRequest
+        {
+            BookId = "book-null",
+            From = DateTimeOffset.UtcNow.AddDays(-1),
+            To = DateTimeOffset.UtcNow,
+        };
+
+        var act = async () => await sut.GetSummaryAsync(request);
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Book analytics summary payload was empty");
+    }
+
+    private static string BuildExpectedPath(string bookId, DateTimeOffset from, DateTimeOffset to)
+    {
+        return $"/book-analytics/summary?bookId={Uri.EscapeDataString(bookId)}&from={Uri.EscapeDataString(from.ToString("O", System.Globalization.CultureInfo.InvariantCulture))}&to={Uri.EscapeDataString(to.ToString("O", System.Globalization.CultureInfo.InvariantCulture))}";
+    }
+}

--- a/tests/PublishingPlatform.SDK.Tests/BookAnalytics/BookAnalyticsCollaboratorsTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/BookAnalytics/BookAnalyticsCollaboratorsTests.cs
@@ -1,0 +1,104 @@
+using System.Text;
+using Bogus;
+using PublishingPlatform.SDK.Clients.BookAnalytics.Serialization;
+using PublishingPlatform.SDK.Clients.BookAnalytics.Validation;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Tests.BookAnalytics;
+
+public sealed class BookAnalyticsCollaboratorsTests
+{
+    [Fact]
+    public void Validator_Throws_WhenBookIdMissing()
+    {
+        var validator = new DefaultBookAnalyticsRequestValidator();
+        var request = new GetBookAnalyticsRequest
+        {
+            BookId = " ",
+            From = DateTimeOffset.UtcNow.AddDays(-1),
+            To = DateTimeOffset.UtcNow,
+        };
+
+        Action act = () => validator.ValidateGetSummary(request);
+
+        act.Should().Throw<BookValidationException>()
+            .WithMessage("*Book id is required*");
+    }
+
+    [Fact]
+    public void Validator_Throws_WhenToMissing()
+    {
+        var validator = new DefaultBookAnalyticsRequestValidator();
+        var request = new GetBookAnalyticsRequest
+        {
+            BookId = "book-1",
+            From = DateTimeOffset.UtcNow.AddDays(-1),
+            To = null,
+        };
+
+        Action act = () => validator.ValidateGetSummary(request);
+
+        act.Should().Throw<BookValidationException>()
+            .WithMessage("*To is required*");
+    }
+
+    [Fact]
+    public void Validator_Throws_WhenRangeIsInvalid()
+    {
+        var validator = new DefaultBookAnalyticsRequestValidator();
+        var request = new GetBookAnalyticsRequest
+        {
+            BookId = "book-1",
+            From = DateTimeOffset.UtcNow,
+            To = DateTimeOffset.UtcNow.AddDays(-1),
+        };
+
+        Action act = () => validator.ValidateGetSummary(request);
+
+        act.Should().Throw<BookValidationException>()
+            .WithMessage("*From must be less than or equal to To*");
+    }
+
+    [Fact]
+    public void QueryBuilder_BuildsDeterministicPath_AndOmitsFutureFacingFields()
+    {
+        Randomizer.Seed = new Random(54);
+        var faker = new Faker();
+        var builder = new DefaultBookAnalyticsQueryStringBuilder();
+        var from = new DateTimeOffset(2026, 5, 1, 0, 0, 0, TimeSpan.Zero);
+        var to = new DateTimeOffset(2026, 5, 7, 23, 59, 59, TimeSpan.Zero);
+        var request = new GetBookAnalyticsRequest
+        {
+            BookId = $"book {faker.Random.Number(10, 99)}",
+            From = from,
+            To = to,
+            Granularity = "month",
+            IncludeUniqueReaders = false,
+        };
+
+        var path = builder.BuildSummaryPath(request);
+
+        path.Should().StartWith("/book-analytics/summary?");
+        path.Should().Contain($"bookId={Uri.EscapeDataString(request.BookId)}");
+        path.Should().Contain($"from={Uri.EscapeDataString(from.ToString("O", System.Globalization.CultureInfo.InvariantCulture))}");
+        path.Should().Contain($"to={Uri.EscapeDataString(to.ToString("O", System.Globalization.CultureInfo.InvariantCulture))}");
+        path.Should().NotContain("granularity=");
+        path.Should().NotContain("includeUniqueReaders=");
+    }
+
+    [Fact]
+    public async Task ResponseReader_Throws_WhenPayloadIsNull()
+    {
+        var reader = new DefaultBookAnalyticsResponseReader();
+        using var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, "application/json"),
+        };
+
+        Func<Task> act = async () => await reader.ReadSummaryAsync(response, CancellationToken.None);
+
+        _ = await act.Should().ThrowAsync<BookValidationException>()
+            .WithMessage("*payload was empty*");
+    }
+}


### PR DESCRIPTION
# Summary

Implements GitHub issue #53 by exposing book analytics summary retrieval through the public SDK analytics contract and concrete client.

- Added `IBookAnalyticsClient.GetSummaryAsync(GetBookAnalyticsRequest, CancellationToken)` as a public operation.
- Implemented `BookAnalyticsClient.GetSummaryAsync` using shared transport with operation name `BookAnalytics.GetSummary`.
- Added dedicated analytics collaborators to keep orchestration, validation, query construction, and response parsing separated:
  - `DefaultBookAnalyticsRequestValidator`
  - `DefaultBookAnalyticsQueryStringBuilder`
  - `DefaultBookAnalyticsResponseReader`
- Enforced request validation for required `BookId`, `From`, `To`, and valid range (`From <= To`) before transport calls.
- Mapped request to deterministic query path:
  - `/book-analytics/summary?bookId=...&from=...&to=...`
- Preserved contract alignment by omitting unsupported future-facing fields (`Granularity`, `IncludeUniqueReaders`) from query mapping.
- Updated README analytics section and request model XML docs to reflect current behavior and future-facing fields.

API impact:

- `IBookAnalyticsClient` is no longer placeholder-only and now exposes one public method:
  - `Task<AnalyticsSummary> GetSummaryAsync(GetBookAnalyticsRequest request, CancellationToken cancellationToken = default)`

# Validation

- [x] `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal --filter "FullyQualifiedName~BookAnalytics"` (Passed: 13, Failed: 0)
- [x] `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal` (Passed: 173, Failed: 0)
- [x] Added focused analytics client and collaborator tests for success, guard clauses, deterministic query encoding, and null payload handling.

# Release Please Override (Required for releasable changes)

```text
BEGIN_COMMIT_OVERRIDE
docs: implement book analytics summary client operation
END_COMMIT_OVERRIDE
```

# Manual NuGet Publish

1. Confirm `Directory.Build.props` version equals intended release version.
2. Create matching tag `v<version>` on the exact commit being published.
3. Run the `Publish NuGet` workflow manually using that tag.
4. Verify the package with the same `<version>` is published on NuGet.
