### PR TITLE
RPS-55 docs: Implement Issue #55 by exposing and wiring a full audit-log list operation for SDK consumers.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.13</Version>
+    <Version>0.0.14</Version>
   </PropertyGroup>
 </Project>

--- a/src/PublishingPlatform.SDK/Abstractions/IBookAuditLogsClient.cs
+++ b/src/PublishingPlatform.SDK/Abstractions/IBookAuditLogsClient.cs
@@ -1,5 +1,20 @@
-﻿namespace PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Models.Common;
 
+namespace PublishingPlatform.SDK.Abstractions;
+
+/// <summary>
+/// Provides audit-log listing operations for books.
+/// </summary>
 public interface IBookAuditLogsClient
 {
+    /// <summary>
+    /// Lists paged audit log entries for the requested filtering criteria.
+    /// </summary>
+    /// <param name="request">The audit-log query criteria.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A paged audit log result.</returns>
+    Task<PagedResult<AuditLog>> ListAsync(
+        ListBookAuditLogsRequest request,
+        CancellationToken cancellationToken = default);
 }

--- a/src/PublishingPlatform.SDK/Clients/BookAccess/Serialization/DefaultBookAccessQueryStringBuilder.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAccess/Serialization/DefaultBookAccessQueryStringBuilder.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using PublishingPlatform.SDK.Clients.Common.Serialization;
 using PublishingPlatform.SDK.Models;
 
 namespace PublishingPlatform.SDK.Clients.BookAccess.Serialization;
@@ -27,32 +28,13 @@ internal sealed class DefaultBookAccessQueryStringBuilder : IBookAccessQueryStri
             : $"/books/{Uri.EscapeDataString(request.BookId)}/access";
 
         var builder = new StringBuilder(path);
-        builder.Append('?');
-        AppendQuery(builder, "pageSize", request.PageSize.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        QueryStringBuilderHelper.AppendRequired(builder, "pageSize", request.PageSize.ToString(System.Globalization.CultureInfo.InvariantCulture), isFirstParameter: true);
 
-        AppendOptionalQuery(builder, "continuationToken", request.ContinuationToken);
-        AppendOptionalQuery(builder, "principalId", request.PrincipalId);
-        AppendOptionalQuery(builder, "principalType", request.PrincipalType);
-        AppendOptionalQuery(builder, "accessLevel", request.AccessLevel);
+        _ = QueryStringBuilderHelper.AppendOptional(builder, "continuationToken", request.ContinuationToken, isFirstParameter: false);
+        _ = QueryStringBuilderHelper.AppendOptional(builder, "principalId", request.PrincipalId, isFirstParameter: false);
+        _ = QueryStringBuilderHelper.AppendOptional(builder, "principalType", request.PrincipalType, isFirstParameter: false);
+        _ = QueryStringBuilderHelper.AppendOptional(builder, "accessLevel", request.AccessLevel, isFirstParameter: false);
 
         return builder.ToString();
-    }
-
-    private static void AppendOptionalQuery(StringBuilder builder, string key, string? value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return;
-        }
-
-        builder.Append('&');
-        AppendQuery(builder, key, value);
-    }
-
-    private static void AppendQuery(StringBuilder builder, string key, string value)
-    {
-        builder.Append(Uri.EscapeDataString(key));
-        builder.Append('=');
-        builder.Append(Uri.EscapeDataString(value));
     }
 }

--- a/src/PublishingPlatform.SDK/Clients/BookAuditLogs/Serialization/DefaultBookAuditLogsQueryStringBuilder.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAuditLogs/Serialization/DefaultBookAuditLogsQueryStringBuilder.cs
@@ -1,0 +1,44 @@
+using System.Globalization;
+using System.Text;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookAuditLogs.Serialization;
+
+/// <summary>
+/// Builds deterministic audit-log query strings with optional filters.
+/// </summary>
+internal sealed class DefaultBookAuditLogsQueryStringBuilder : IBookAuditLogsQueryStringBuilder
+{
+    /// <inheritdoc />
+    public string BuildListPath(ListBookAuditLogsRequest request)
+    {
+        var builder = new StringBuilder("/book-audit-logs?");
+        AppendQuery(builder, "page", request.Page.ToString(CultureInfo.InvariantCulture));
+        builder.Append('&');
+        AppendQuery(builder, "pageSize", request.PageSize.ToString(CultureInfo.InvariantCulture));
+
+        AppendOptionalQuery(builder, "continuationToken", request.ContinuationToken);
+        AppendOptionalQuery(builder, "bookId", request.BookId);
+        AppendOptionalQuery(builder, "action", request.Action);
+
+        return builder.ToString();
+    }
+
+    private static void AppendOptionalQuery(StringBuilder builder, string key, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return;
+        }
+
+        builder.Append('&');
+        AppendQuery(builder, key, value);
+    }
+
+    private static void AppendQuery(StringBuilder builder, string key, string value)
+    {
+        builder.Append(Uri.EscapeDataString(key));
+        builder.Append('=');
+        builder.Append(Uri.EscapeDataString(value));
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/BookAuditLogs/Serialization/DefaultBookAuditLogsQueryStringBuilder.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAuditLogs/Serialization/DefaultBookAuditLogsQueryStringBuilder.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text;
+using PublishingPlatform.SDK.Clients.Common.Serialization;
 using PublishingPlatform.SDK.Models;
 
 namespace PublishingPlatform.SDK.Clients.BookAuditLogs.Serialization;
@@ -12,33 +13,14 @@ internal sealed class DefaultBookAuditLogsQueryStringBuilder : IBookAuditLogsQue
     /// <inheritdoc />
     public string BuildListPath(ListBookAuditLogsRequest request)
     {
-        var builder = new StringBuilder("/book-audit-logs?");
-        AppendQuery(builder, "page", request.Page.ToString(CultureInfo.InvariantCulture));
-        builder.Append('&');
-        AppendQuery(builder, "pageSize", request.PageSize.ToString(CultureInfo.InvariantCulture));
+        var builder = new StringBuilder("/book-audit-logs");
+        QueryStringBuilderHelper.AppendRequired(builder, "page", request.Page.ToString(CultureInfo.InvariantCulture), isFirstParameter: true);
+        QueryStringBuilderHelper.AppendRequired(builder, "pageSize", request.PageSize.ToString(CultureInfo.InvariantCulture), isFirstParameter: false);
 
-        AppendOptionalQuery(builder, "continuationToken", request.ContinuationToken);
-        AppendOptionalQuery(builder, "bookId", request.BookId);
-        AppendOptionalQuery(builder, "action", request.Action);
+        _ = QueryStringBuilderHelper.AppendOptional(builder, "continuationToken", request.ContinuationToken, isFirstParameter: false);
+        _ = QueryStringBuilderHelper.AppendOptional(builder, "bookId", request.BookId, isFirstParameter: false);
+        _ = QueryStringBuilderHelper.AppendOptional(builder, "action", request.Action, isFirstParameter: false);
 
         return builder.ToString();
-    }
-
-    private static void AppendOptionalQuery(StringBuilder builder, string key, string? value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return;
-        }
-
-        builder.Append('&');
-        AppendQuery(builder, key, value);
-    }
-
-    private static void AppendQuery(StringBuilder builder, string key, string value)
-    {
-        builder.Append(Uri.EscapeDataString(key));
-        builder.Append('=');
-        builder.Append(Uri.EscapeDataString(value));
     }
 }

--- a/src/PublishingPlatform.SDK/Clients/BookAuditLogs/Serialization/DefaultBookAuditLogsResponseReader.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAuditLogs/Serialization/DefaultBookAuditLogsResponseReader.cs
@@ -1,0 +1,24 @@
+using System.Net.Http.Json;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Models.Common;
+
+namespace PublishingPlatform.SDK.Clients.BookAuditLogs.Serialization;
+
+/// <summary>
+/// Parses audit-log responses and enforces non-empty payloads.
+/// </summary>
+internal sealed class DefaultBookAuditLogsResponseReader : IBookAuditLogsResponseReader
+{
+    /// <inheritdoc />
+    public async Task<PagedResult<AuditLog>> ReadListAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        var payload = await response.Content.ReadFromJsonAsync<PagedResult<AuditLog>>(ct).ConfigureAwait(false);
+        if (payload is null)
+        {
+            throw new BookValidationException("Paged book audit logs payload was empty.");
+        }
+
+        return payload;
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/BookAuditLogs/Serialization/IBookAuditLogsQueryStringBuilder.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAuditLogs/Serialization/IBookAuditLogsQueryStringBuilder.cs
@@ -1,0 +1,16 @@
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookAuditLogs.Serialization;
+
+/// <summary>
+/// Builds deterministic audit-log list query paths.
+/// </summary>
+internal interface IBookAuditLogsQueryStringBuilder
+{
+    /// <summary>
+    /// Builds a relative path for audit-log list requests.
+    /// </summary>
+    /// <param name="request">The request containing route and query criteria.</param>
+    /// <returns>The relative request path including query string.</returns>
+    string BuildListPath(ListBookAuditLogsRequest request);
+}

--- a/src/PublishingPlatform.SDK/Clients/BookAuditLogs/Serialization/IBookAuditLogsResponseReader.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAuditLogs/Serialization/IBookAuditLogsResponseReader.cs
@@ -1,0 +1,18 @@
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Models.Common;
+
+namespace PublishingPlatform.SDK.Clients.BookAuditLogs.Serialization;
+
+/// <summary>
+/// Reads and validates audit-log list responses.
+/// </summary>
+internal interface IBookAuditLogsResponseReader
+{
+    /// <summary>
+    /// Reads an audit-log list response payload.
+    /// </summary>
+    /// <param name="response">The HTTP response containing payload data.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The parsed paged audit-log result.</returns>
+    Task<PagedResult<AuditLog>> ReadListAsync(HttpResponseMessage response, CancellationToken ct);
+}

--- a/src/PublishingPlatform.SDK/Clients/BookAuditLogs/Validation/DefaultBookAuditLogsRequestValidator.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAuditLogs/Validation/DefaultBookAuditLogsRequestValidator.cs
@@ -1,0 +1,24 @@
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookAuditLogs.Validation;
+
+/// <summary>
+/// Enforces validation rules for audit-log list requests.
+/// </summary>
+internal sealed class DefaultBookAuditLogsRequestValidator : IBookAuditLogsRequestValidator
+{
+    /// <inheritdoc />
+    public void ValidateList(ListBookAuditLogsRequest request)
+    {
+        if (request.Page < 0)
+        {
+            throw new BookValidationException("Page must be greater than or equal to 0.");
+        }
+
+        if (request.PageSize < 1 || request.PageSize > 500)
+        {
+            throw new BookValidationException("PageSize must be between 1 and 500.");
+        }
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/BookAuditLogs/Validation/IBookAuditLogsRequestValidator.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAuditLogs/Validation/IBookAuditLogsRequestValidator.cs
@@ -1,0 +1,15 @@
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.BookAuditLogs.Validation;
+
+/// <summary>
+/// Validates audit-log list requests before transport execution.
+/// </summary>
+internal interface IBookAuditLogsRequestValidator
+{
+    /// <summary>
+    /// Validates an audit-log list request.
+    /// </summary>
+    /// <param name="request">The request to validate.</param>
+    void ValidateList(ListBookAuditLogsRequest request);
+}

--- a/src/PublishingPlatform.SDK/Clients/BookAuditLogsClient.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAuditLogsClient.cs
@@ -1,14 +1,72 @@
+using System.Diagnostics;
 using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Clients.BookAuditLogs.Serialization;
+using PublishingPlatform.SDK.Clients.BookAuditLogs.Validation;
+using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Transport;
+using PublishingPlatform.SDK.Internal;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Models.Common;
 
 namespace PublishingPlatform.SDK.Clients;
 
+/// <summary>
+/// Orchestrates book audit-log list operations through the shared transport.
+/// </summary>
 public sealed class BookAuditLogsClient : IBookAuditLogsClient
 {
+    private const string ListOperationName = "BookAuditLogs.List";
     private readonly ISharedHttpTransport _transport;
+    private readonly IBookAuditLogsRequestValidator _validator;
+    private readonly IBookAuditLogsQueryStringBuilder _queryStringBuilder;
+    private readonly IBookAuditLogsResponseReader _responseReader;
 
     internal BookAuditLogsClient(ISharedHttpTransport transport)
+        : this(
+            transport,
+            new DefaultBookAuditLogsRequestValidator(),
+            new DefaultBookAuditLogsQueryStringBuilder(),
+            new DefaultBookAuditLogsResponseReader())
+    {
+    }
+
+    internal BookAuditLogsClient(
+        ISharedHttpTransport transport,
+        IBookAuditLogsRequestValidator validator,
+        IBookAuditLogsQueryStringBuilder queryStringBuilder,
+        IBookAuditLogsResponseReader responseReader)
     {
         _transport = transport;
+        _validator = validator;
+        _queryStringBuilder = queryStringBuilder;
+        _responseReader = responseReader;
+    }
+
+    /// <inheritdoc />
+    public async Task<PagedResult<AuditLog>> ListAsync(
+        ListBookAuditLogsRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        Guards.NotNull(request, nameof(request));
+        _validator.ValidateList(request);
+
+        using var activity = StartActivity(ListOperationName);
+        var relativePath = _queryStringBuilder.BuildListPath(request);
+        using var response = await _transport.SendAsync(
+            HttpMethod.Get,
+            relativePath,
+            null,
+            null,
+            ListOperationName,
+            cancellationToken).ConfigureAwait(false);
+
+        return await _responseReader.ReadListAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static Activity? StartActivity(string operationName)
+    {
+        var activity = ActivitySourceProvider.ActivitySource.StartActivity(operationName, ActivityKind.Client);
+        activity?.SetTag("sdk.operation", operationName);
+        return activity;
     }
 }

--- a/src/PublishingPlatform.SDK/Clients/Common/Serialization/QueryStringBuilderHelper.cs
+++ b/src/PublishingPlatform.SDK/Clients/Common/Serialization/QueryStringBuilderHelper.cs
@@ -1,0 +1,54 @@
+using System.Text;
+
+namespace PublishingPlatform.SDK.Clients.Common.Serialization;
+
+/// <summary>
+/// Provides shared URL-encoded query-string append helpers for SDK client builders.
+/// </summary>
+internal static class QueryStringBuilderHelper
+{
+    /// <summary>
+    /// Appends a required query parameter.
+    /// </summary>
+    /// <param name="builder">The destination query-string builder.</param>
+    /// <param name="key">The query parameter name.</param>
+    /// <param name="value">The query parameter value.</param>
+    /// <param name="isFirstParameter">Whether this is the first query parameter in the string.</param>
+    public static void AppendRequired(StringBuilder builder, string key, string value, bool isFirstParameter)
+    {
+        AppendSeparator(builder, isFirstParameter);
+        AppendEncoded(builder, key, value);
+    }
+
+    /// <summary>
+    /// Appends an optional query parameter when a non-empty value is provided.
+    /// </summary>
+    /// <param name="builder">The destination query-string builder.</param>
+    /// <param name="key">The query parameter name.</param>
+    /// <param name="value">The query parameter value.</param>
+    /// <param name="isFirstParameter">Whether this is the first query parameter in the string.</param>
+    /// <returns><see langword="true"/> when the value was appended; otherwise <see langword="false"/>.</returns>
+    public static bool AppendOptional(StringBuilder builder, string key, string? value, bool isFirstParameter)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        AppendSeparator(builder, isFirstParameter);
+        AppendEncoded(builder, key, value);
+        return true;
+    }
+
+    private static void AppendSeparator(StringBuilder builder, bool isFirstParameter)
+    {
+        builder.Append(isFirstParameter ? '?' : '&');
+    }
+
+    private static void AppendEncoded(StringBuilder builder, string key, string value)
+    {
+        builder.Append(Uri.EscapeDataString(key));
+        builder.Append('=');
+        builder.Append(Uri.EscapeDataString(value));
+    }
+}

--- a/src/PublishingPlatform.SDK/Models/ListBookAuditLogsRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/ListBookAuditLogsRequest.cs
@@ -44,4 +44,9 @@ public sealed class ListBookAuditLogsRequest
     /// Gets or sets requested page size.
     /// </summary>
     public int PageSize { get; set; } = 50;
+
+    /// <summary>
+    /// Gets or sets an optional continuation token.
+    /// </summary>
+    public string? ContinuationToken { get; set; }
 }

--- a/tests/PublishingPlatform.SDK.Tests/BookAuditLogs/BookAuditLogsClientTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/BookAuditLogs/BookAuditLogsClientTests.cs
@@ -1,0 +1,245 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using Bogus;
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Clients.BookAuditLogs.Serialization;
+using PublishingPlatform.SDK.Clients.BookAuditLogs.Validation;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Infrastructure.Errors;
+using PublishingPlatform.SDK.Infrastructure.Transport;
+using PublishingPlatform.SDK.Internal.Resilience;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Models.Common;
+
+namespace PublishingPlatform.SDK.Tests.BookAuditLogs;
+
+public sealed class BookAuditLogsClientTests
+{
+    [Fact]
+    public async Task ListAsync_SendsGetWithExpectedRouteAndCancellation()
+    {
+        Randomizer.Seed = new Random(55);
+        var faker = new Faker();
+        var token = new CancellationTokenSource().Token;
+        var request = new ListBookAuditLogsRequest
+        {
+            Page = 2,
+            PageSize = 25,
+            ContinuationToken = faker.Random.AlphaNumeric(8),
+            BookId = $"book {faker.Random.Number(100, 999)}+{faker.Random.Number(1, 9)}",
+            Action = "book.updated",
+        };
+        var expectedPath = BuildExpectedPath(request);
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+            HttpMethod.Get,
+            expectedPath,
+            null,
+            null,
+            "BookAuditLogs.List",
+            token).Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new PagedResult<AuditLog>
+                {
+                    Items =
+                    [
+                        new AuditLog
+                        {
+                            Id = "log-1",
+                            Action = "book.updated",
+                            Timestamp = DateTimeOffset.UtcNow,
+                        },
+                    ],
+                }),
+            }));
+        var sut = new BookAuditLogsClient(transport);
+
+        var result = await sut.ListAsync(request, token);
+
+        result.Items.Should().HaveCount(1);
+        result.Items[0].Id.Should().Be("log-1");
+        await transport.Received(1).SendAsync(
+            HttpMethod.Get,
+            expectedPath,
+            null,
+            null,
+            "BookAuditLogs.List",
+            token);
+    }
+
+    [Fact]
+    public async Task ListAsync_ThrowsArgumentNullException_ForNullRequest()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        var sut = new BookAuditLogsClient(transport);
+
+        var act = async () => await sut.ListAsync(null!);
+
+        var ex = await act.Should().ThrowAsync<ArgumentNullException>();
+        ex.Which.ParamName.Should().Be("request");
+        await transport.DidNotReceiveWithAnyArgs().SendAsync(default!, default!, default, default, default!, default);
+    }
+
+    [Theory]
+    [InlineData(-1, 10, "Page must be greater than or equal to 0.")]
+    [InlineData(0, 0, "PageSize must be between 1 and 500.")]
+    [InlineData(0, 501, "PageSize must be between 1 and 500.")]
+    public async Task ListAsync_ThrowsBookValidationException_ForInvalidPagination(int page, int pageSize, string expectedMessage)
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        var sut = new BookAuditLogsClient(transport);
+
+        var act = async () => await sut.ListAsync(new ListBookAuditLogsRequest
+        {
+            Page = page,
+            PageSize = pageSize,
+        });
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain(expectedMessage);
+        await transport.DidNotReceiveWithAnyArgs().SendAsync(default!, default!, default, default, default!, default);
+    }
+
+    [Fact]
+    public async Task ListAsync_OmitsOptionalFilters_WhenNullOrWhitespace()
+    {
+        var request = new ListBookAuditLogsRequest
+        {
+            Page = 0,
+            PageSize = 50,
+            ContinuationToken = " ",
+            BookId = " ",
+            Action = null,
+        };
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+            HttpMethod.Get,
+            "/book-audit-logs?page=0&pageSize=50",
+            null,
+            null,
+            "BookAuditLogs.List",
+            Arg.Any<CancellationToken>()).Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new PagedResult<AuditLog>
+                {
+                    Items = Array.Empty<AuditLog>(),
+                }),
+            }));
+        var sut = new BookAuditLogsClient(transport);
+
+        _ = await sut.ListAsync(request);
+
+        await transport.Received(1).SendAsync(
+            HttpMethod.Get,
+            "/book-audit-logs?page=0&pageSize=50",
+            null,
+            null,
+            "BookAuditLogs.List",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListAsync_ThrowsBookValidationException_WhenPayloadIsNull()
+    {
+        using var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, "application/json"),
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.test") };
+        var transport = new SharedHttpTransport(client, new NoOpPublishingPlatformResiliencePipeline(), new FixedCorrelationIdProvider(), new DefaultPublishingPlatformErrorMapper());
+        var sut = new BookAuditLogsClient(transport);
+
+        var act = async () => await sut.ListAsync(new ListBookAuditLogsRequest
+        {
+            Page = 0,
+            PageSize = 10,
+        });
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Paged book audit logs payload was empty");
+    }
+
+    [Fact]
+    public void QueryStringBuilder_BuildsDeterministicEncodedPath()
+    {
+        var builder = new DefaultBookAuditLogsQueryStringBuilder();
+        var request = new ListBookAuditLogsRequest
+        {
+            Page = 3,
+            PageSize = 15,
+            ContinuationToken = "ct+1/2",
+            BookId = "book 1/2",
+            Action = "book.updated+published",
+            ActorId = "actor-ignored",
+            CorrelationId = "corr-ignored",
+        };
+
+        var path = builder.BuildListPath(request);
+
+        path.Should().Be("/book-audit-logs?page=3&pageSize=15&continuationToken=ct%2B1%2F2&bookId=book%201%2F2&action=book.updated%2Bpublished");
+        path.Should().NotContain("actorId=");
+        path.Should().NotContain("from=");
+        path.Should().NotContain("to=");
+        path.Should().NotContain("correlationId=");
+    }
+
+    [Fact]
+    public async Task ResponseReader_ThrowsBookValidationException_WhenPayloadIsNull()
+    {
+        var reader = new DefaultBookAuditLogsResponseReader();
+        using var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, "application/json"),
+        };
+
+        var act = async () => await reader.ReadListAsync(response, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Paged book audit logs payload was empty");
+    }
+
+    [Fact]
+    public void Validator_ThrowsBookValidationException_WhenPageSizeIsOutOfRange()
+    {
+        var validator = new DefaultBookAuditLogsRequestValidator();
+        var request = new ListBookAuditLogsRequest
+        {
+            Page = 0,
+            PageSize = 700,
+        };
+
+        Action act = () => validator.ValidateList(request);
+
+        var ex = act.Should().Throw<BookValidationException>();
+        ex.Which.Message.Should().Contain("PageSize must be between 1 and 500");
+    }
+
+    private static string BuildExpectedPath(ListBookAuditLogsRequest request)
+    {
+        return $"/book-audit-logs?page={request.Page}&pageSize={request.PageSize}&continuationToken={Uri.EscapeDataString(request.ContinuationToken!)}&bookId={Uri.EscapeDataString(request.BookId)}&action={Uri.EscapeDataString(request.Action!)}";
+    }
+
+    private sealed class SingleResponseHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+
+        public SingleResponseHandler(HttpResponseMessage response)
+        {
+            _response = response;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_response);
+        }
+    }
+
+    private sealed class FixedCorrelationIdProvider : ICorrelationIdProvider
+    {
+        public string Create()
+        {
+            return Guid.NewGuid().ToString("N");
+        }
+    }
+}

--- a/tests/PublishingPlatform.SDK.Tests/Models/RequestModelContractsTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Models/RequestModelContractsTests.cs
@@ -35,6 +35,7 @@ public sealed class RequestModelContractsTests
 
         request.Page.Should().Be(0);
         request.PageSize.Should().Be(50);
+        request.ContinuationToken.Should().BeNull();
         request.ActorId.Should().BeNull();
         request.CorrelationId.Should().BeNull();
     }


### PR DESCRIPTION
# Summary

Implement Issue #55 by exposing and wiring a full audit-log list operation for SDK consumers.

What changed:
- Added `IBookAuditLogsClient.ListAsync(ListBookAuditLogsRequest, CancellationToken)` as a new public client contract.
- Implemented `BookAuditLogsClient.ListAsync(...)` as orchestration-only logic over shared transport (`GET /book-audit-logs`, operation `BookAuditLogs.List`).
- Added dedicated collaborators for layered responsibilities:
  - validation: `IBookAuditLogsRequestValidator`, `DefaultBookAuditLogsRequestValidator`
  - query building: `IBookAuditLogsQueryStringBuilder`, `DefaultBookAuditLogsQueryStringBuilder`
  - response reading: `IBookAuditLogsResponseReader`, `DefaultBookAuditLogsResponseReader`
- Enforced validation and mapping rules:
  - page must be `>= 0`
  - page size must be `1..500`
  - mapped query fields: `page`, `pageSize`, `continuationToken`, `bookId`, `action`
  - unsupported request fields (`ActorId`, `From`, `To`, `CorrelationId`) are intentionally not transmitted
- Added additive request model field `ContinuationToken` to `ListBookAuditLogsRequest`.
- Added focused unit tests for client orchestration, validation failures, deterministic URI encoding, optional filter omission, and null payload exception behavior.

API impact:
- Additive public API change: `IBookAuditLogsClient` now exposes `ListAsync(...)`.
- Additive public model change: `ListBookAuditLogsRequest` now includes `ContinuationToken`.
- No breaking changes introduced.

# Validation

- [x] `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal`
- [x] Added/updated tests for audit logs client behavior and request defaults

Test result evidence:
- Passed: 183
- Failed: 0
- Skipped: 0

# Release Please Override (Required for releasable changes)

```text
BEGIN_COMMIT_OVERRIDE
docs: add paged book audit logs list client operation
END_COMMIT_OVERRIDE
```

# Manual NuGet Publish

1. Confirm `Directory.Build.props` version equals the intended release version.
2. Create matching tag `v<version>` on that exact commit.
3. Run `Publish NuGet` workflow manually with the same tag.
4. Verify the published package version appears on NuGet.
