### PR TITLE
RPS-56 feat: Implement the `IWebhooksClient` module for RPS-56 so SDK consumers can manage webhook callback registrations through the existing root client.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.0.14</Version>
+    <Version>0.0.15</Version>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -243,18 +243,43 @@ Module accessor for webhook-oriented integration workflows.
 Current status:
 
 - Property is available on the root client.
-- Interface is currently a placeholder (no public operations yet in this SDK version).
+- `RegisterAsync(RegisterWebhookRequest, idempotencyKey, CancellationToken)` registers an HTTPS callback endpoint.
+- `UpdateAsync(UpdateWebhookRequest, CancellationToken)` updates endpoint settings and subscribed events.
+- `DeleteAsync(webhookId, CancellationToken)` removes a webhook registration.
+- `ListAsync(ListWebhooksRequest, CancellationToken)` lists webhook registrations with optional filters.
 
-Typical use cases once expanded:
+Typical use cases:
 
 - Registering callback endpoints.
 - Receiving event notifications for asynchronous platform events.
+- Keeping external systems synchronized with book lifecycle, publishing, and distribution changes.
+
+Example:
+
+```csharp
+var webhook = await client.Webhooks.RegisterAsync(
+    new RegisterWebhookRequest
+    {
+        EndpointUrl = "https://hooks.example.com/publishing-platform",
+        Events = ["book.published", "book.distribution.completed"],
+        IsActive = true,
+        SigningKeyId = "signing-key-01",
+    },
+    idempotencyKey: "webhook-registration-001");
+
+var page = await client.Webhooks.ListAsync(new ListWebhooksRequest
+{
+    Event = "book.published",
+    IsActive = true,
+});
+```
 
 ## Which module should I use?
 
 - Use `Books` today for production book CRUD/listing flows.
 - Use `BookPublishing` when you need lifecycle state transitions (`publish`, `unpublish`, `schedule`).
 - Use `BookDistribution` when you need downstream propagation and operational delivery tracking.
+- Use `Webhooks` when external systems need asynchronous platform event notifications.
 
 ## Publishing vs distribution architecture
 

--- a/examples/Webhooks/README.md
+++ b/examples/Webhooks/README.md
@@ -1,0 +1,24 @@
+# Webhooks Example
+
+This example demonstrates webhook registration and management through `IWebhooksClient`:
+
+- `RegisterAsync(...)`
+- `UpdateAsync(...)`
+- `ListAsync(...)`
+- `DeleteAsync(...)`
+
+It maps request values to:
+
+- `POST /webhooks`
+- `PATCH /webhooks/{webhookId}`
+- `GET /webhooks?pageSize=...`
+- `DELETE /webhooks/{webhookId}`
+
+Notes:
+
+- Callback endpoints must be absolute HTTPS URLs.
+- `SigningKeyId` identifies a key managed outside the SDK; do not put signing secrets in code or examples.
+
+Run:
+
+- `examples/Webhooks/WebhooksExample.csx`

--- a/examples/Webhooks/WebhooksExample.csx
+++ b/examples/Webhooks/WebhooksExample.csx
@@ -1,0 +1,43 @@
+//r "nuget: PublishingPlatform.SDK"
+
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Options;
+
+var client = PublishingPlatformClientBuilder.Create(new PublishingPlatformClientOptions
+{
+    BaseUrl = "https://api.books.example",
+    ApiKey = "your-api-key",
+}).Build();
+
+var webhook = await client.Webhooks.RegisterAsync(
+    new RegisterWebhookRequest
+    {
+        EndpointUrl = "https://hooks.example.com/publishing-platform",
+        Events = ["book.published", "book.distribution.completed"],
+        IsActive = true,
+        SigningKeyId = "signing-key-01",
+    },
+    idempotencyKey: "webhook-registration-001");
+
+Console.WriteLine($"Registered webhook: {webhook.Id}");
+
+var updated = await client.Webhooks.UpdateAsync(new UpdateWebhookRequest
+{
+    WebhookId = webhook.Id,
+    EndpointUrl = webhook.EndpointUrl,
+    Events = ["book.published", "book.distribution.failed"],
+    IsActive = true,
+});
+
+Console.WriteLine($"Updated webhook events: {string.Join(", ", updated.Events)}");
+
+var page = await client.Webhooks.ListAsync(new ListWebhooksRequest
+{
+    Event = "book.published",
+    IsActive = true,
+});
+
+Console.WriteLine($"Active publishing webhooks: {page.Items.Count}");
+
+await client.Webhooks.DeleteAsync(webhook.Id);

--- a/src/PublishingPlatform.SDK/Abstractions/IWebhooksClient.cs
+++ b/src/PublishingPlatform.SDK/Abstractions/IWebhooksClient.cs
@@ -1,5 +1,52 @@
-﻿namespace PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Models.Common;
 
+namespace PublishingPlatform.SDK.Abstractions;
+
+/// <summary>
+/// Provides webhook registration and management operations for platform integrations.
+/// </summary>
 public interface IWebhooksClient
 {
+    /// <summary>
+    /// Registers a webhook callback endpoint for asynchronous platform events.
+    /// </summary>
+    /// <param name="request">The webhook registration request.</param>
+    /// <param name="idempotencyKey">An optional idempotency key for retry-safe registration.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The registered webhook snapshot.</returns>
+    Task<Webhook> RegisterAsync(
+        RegisterWebhookRequest request,
+        string? idempotencyKey = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates an existing webhook callback endpoint and subscription settings.
+    /// </summary>
+    /// <param name="request">The webhook update request.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The updated webhook snapshot.</returns>
+    Task<Webhook> UpdateAsync(
+        UpdateWebhookRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes a webhook registration by identifier.
+    /// </summary>
+    /// <param name="webhookId">The unique webhook identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that completes when the webhook has been deleted.</returns>
+    Task DeleteAsync(
+        string webhookId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lists webhook registrations with optional filtering.
+    /// </summary>
+    /// <param name="request">The webhook list request.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A paged result of webhook registrations.</returns>
+    Task<PagedResult<Webhook>> ListAsync(
+        ListWebhooksRequest request,
+        CancellationToken cancellationToken = default);
 }

--- a/src/PublishingPlatform.SDK/Clients/Webhooks/Requests/DefaultWebhookRequestHeadersFactory.cs
+++ b/src/PublishingPlatform.SDK/Clients/Webhooks/Requests/DefaultWebhookRequestHeadersFactory.cs
@@ -1,0 +1,23 @@
+namespace PublishingPlatform.SDK.Clients.Webhooks.Requests;
+
+/// <summary>
+/// Produces header sets for webhook management requests.
+/// </summary>
+internal sealed class DefaultWebhookRequestHeadersFactory : IWebhookRequestHeadersFactory
+{
+    private const string IdempotencyHeaderName = "Idempotency-Key";
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<string, string>? CreateIdempotencyHeaders(string? idempotencyKey)
+    {
+        if (string.IsNullOrWhiteSpace(idempotencyKey))
+        {
+            return null;
+        }
+
+        return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [IdempotencyHeaderName] = idempotencyKey,
+        };
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/Webhooks/Requests/IWebhookRequestHeadersFactory.cs
+++ b/src/PublishingPlatform.SDK/Clients/Webhooks/Requests/IWebhookRequestHeadersFactory.cs
@@ -1,0 +1,14 @@
+namespace PublishingPlatform.SDK.Clients.Webhooks.Requests;
+
+/// <summary>
+/// Produces header sets for webhook management requests.
+/// </summary>
+internal interface IWebhookRequestHeadersFactory
+{
+    /// <summary>
+    /// Creates idempotency headers for retry-safe webhook registration.
+    /// </summary>
+    /// <param name="idempotencyKey">The optional idempotency key.</param>
+    /// <returns>A header dictionary when a key is provided; otherwise <see langword="null"/>.</returns>
+    IReadOnlyDictionary<string, string>? CreateIdempotencyHeaders(string? idempotencyKey);
+}

--- a/src/PublishingPlatform.SDK/Clients/Webhooks/Serialization/DefaultWebhookQueryStringBuilder.cs
+++ b/src/PublishingPlatform.SDK/Clients/Webhooks/Serialization/DefaultWebhookQueryStringBuilder.cs
@@ -1,0 +1,45 @@
+using System.Globalization;
+using System.Text;
+using PublishingPlatform.SDK.Clients.Common.Serialization;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.Webhooks.Serialization;
+
+/// <summary>
+/// Builds deterministic URL-encoded webhook list paths.
+/// </summary>
+internal sealed class DefaultWebhookQueryStringBuilder : IWebhookQueryStringBuilder
+{
+    /// <inheritdoc />
+    public string BuildListPath(ListWebhooksRequest request)
+    {
+        var builder = new StringBuilder("/webhooks");
+        QueryStringBuilderHelper.AppendRequired(
+            builder,
+            "pageSize",
+            request.PageSize.ToString(CultureInfo.InvariantCulture),
+            isFirstParameter: true);
+
+        _ = QueryStringBuilderHelper.AppendOptional(
+            builder,
+            "continuationToken",
+            request.ContinuationToken,
+            isFirstParameter: false);
+        _ = QueryStringBuilderHelper.AppendOptional(
+            builder,
+            "event",
+            request.Event,
+            isFirstParameter: false);
+
+        if (request.IsActive.HasValue)
+        {
+            QueryStringBuilderHelper.AppendRequired(
+                builder,
+                "isActive",
+                request.IsActive.Value ? "true" : "false",
+                isFirstParameter: false);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/Webhooks/Serialization/DefaultWebhookResponseReader.cs
+++ b/src/PublishingPlatform.SDK/Clients/Webhooks/Serialization/DefaultWebhookResponseReader.cs
@@ -1,0 +1,36 @@
+using System.Net.Http.Json;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Models.Common;
+
+namespace PublishingPlatform.SDK.Clients.Webhooks.Serialization;
+
+/// <summary>
+/// Reads and validates webhook response payloads.
+/// </summary>
+internal sealed class DefaultWebhookResponseReader : IWebhookResponseReader
+{
+    /// <inheritdoc />
+    public async Task<Webhook> ReadWebhookAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        var payload = await response.Content.ReadFromJsonAsync<Webhook>(cancellationToken).ConfigureAwait(false);
+        if (payload is null)
+        {
+            throw new BookValidationException("Webhook payload was empty.");
+        }
+
+        return payload;
+    }
+
+    /// <inheritdoc />
+    public async Task<PagedResult<Webhook>> ReadPagedWebhooksAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        var payload = await response.Content.ReadFromJsonAsync<PagedResult<Webhook>>(cancellationToken).ConfigureAwait(false);
+        if (payload is null)
+        {
+            throw new BookValidationException("Paged webhooks payload was empty.");
+        }
+
+        return payload;
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/Webhooks/Serialization/IWebhookQueryStringBuilder.cs
+++ b/src/PublishingPlatform.SDK/Clients/Webhooks/Serialization/IWebhookQueryStringBuilder.cs
@@ -1,0 +1,16 @@
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.Webhooks.Serialization;
+
+/// <summary>
+/// Builds deterministic webhook query paths.
+/// </summary>
+internal interface IWebhookQueryStringBuilder
+{
+    /// <summary>
+    /// Builds the webhook list path for a request.
+    /// </summary>
+    /// <param name="request">The list request.</param>
+    /// <returns>The relative list path with query parameters.</returns>
+    string BuildListPath(ListWebhooksRequest request);
+}

--- a/src/PublishingPlatform.SDK/Clients/Webhooks/Serialization/IWebhookResponseReader.cs
+++ b/src/PublishingPlatform.SDK/Clients/Webhooks/Serialization/IWebhookResponseReader.cs
@@ -1,0 +1,26 @@
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Models.Common;
+
+namespace PublishingPlatform.SDK.Clients.Webhooks.Serialization;
+
+/// <summary>
+/// Reads and validates webhook response payloads.
+/// </summary>
+internal interface IWebhookResponseReader
+{
+    /// <summary>
+    /// Reads a webhook response payload.
+    /// </summary>
+    /// <param name="response">The HTTP response.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The webhook payload.</returns>
+    Task<Webhook> ReadWebhookAsync(HttpResponseMessage response, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Reads a paged webhook response payload.
+    /// </summary>
+    /// <param name="response">The HTTP response.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The paged webhook payload.</returns>
+    Task<PagedResult<Webhook>> ReadPagedWebhooksAsync(HttpResponseMessage response, CancellationToken cancellationToken);
+}

--- a/src/PublishingPlatform.SDK/Clients/Webhooks/Validation/DefaultWebhookRequestValidator.cs
+++ b/src/PublishingPlatform.SDK/Clients/Webhooks/Validation/DefaultWebhookRequestValidator.cs
@@ -1,0 +1,76 @@
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.Webhooks.Validation;
+
+/// <summary>
+/// Enforces input validation rules for webhook management operations.
+/// </summary>
+internal sealed class DefaultWebhookRequestValidator : IWebhookRequestValidator
+{
+    private const int MinimumPageSize = 1;
+    private const int MaximumPageSize = 500;
+
+    /// <inheritdoc />
+    public void ValidateRegister(RegisterWebhookRequest request)
+    {
+        ValidateEndpointUrl(request.EndpointUrl);
+        ValidateEvents(request.Events);
+    }
+
+    /// <inheritdoc />
+    public void ValidateUpdate(UpdateWebhookRequest request)
+    {
+        ValidateWebhookId(request.WebhookId);
+        ValidateEndpointUrl(request.EndpointUrl);
+        ValidateEvents(request.Events);
+    }
+
+    /// <inheritdoc />
+    public void ValidateWebhookId(string webhookId)
+    {
+        if (string.IsNullOrWhiteSpace(webhookId))
+        {
+            throw new BookValidationException("Webhook id is required.");
+        }
+    }
+
+    /// <inheritdoc />
+    public void ValidateList(ListWebhooksRequest request)
+    {
+        if (request.PageSize is < MinimumPageSize or > MaximumPageSize)
+        {
+            throw new BookValidationException("PageSize must be between 1 and 500.");
+        }
+    }
+
+    private static void ValidateEndpointUrl(string endpointUrl)
+    {
+        if (string.IsNullOrWhiteSpace(endpointUrl))
+        {
+            throw new BookValidationException("Webhook endpoint URL is required.");
+        }
+
+        if (!Uri.TryCreate(endpointUrl, UriKind.Absolute, out var uri) ||
+            !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new BookValidationException("Webhook endpoint URL must be an absolute HTTPS URL.");
+        }
+    }
+
+    private static void ValidateEvents(IReadOnlyList<string> events)
+    {
+        if (events.Count == 0)
+        {
+            throw new BookValidationException("At least one webhook event is required.");
+        }
+
+        foreach (var webhookEvent in events)
+        {
+            if (string.IsNullOrWhiteSpace(webhookEvent))
+            {
+                throw new BookValidationException("Webhook events cannot contain empty values.");
+            }
+        }
+    }
+}

--- a/src/PublishingPlatform.SDK/Clients/Webhooks/Validation/IWebhookRequestValidator.cs
+++ b/src/PublishingPlatform.SDK/Clients/Webhooks/Validation/IWebhookRequestValidator.cs
@@ -1,0 +1,33 @@
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Clients.Webhooks.Validation;
+
+/// <summary>
+/// Validates webhook management requests before transport execution.
+/// </summary>
+internal interface IWebhookRequestValidator
+{
+    /// <summary>
+    /// Validates a webhook registration request.
+    /// </summary>
+    /// <param name="request">The registration request.</param>
+    void ValidateRegister(RegisterWebhookRequest request);
+
+    /// <summary>
+    /// Validates a webhook update request.
+    /// </summary>
+    /// <param name="request">The update request.</param>
+    void ValidateUpdate(UpdateWebhookRequest request);
+
+    /// <summary>
+    /// Validates a webhook identifier.
+    /// </summary>
+    /// <param name="webhookId">The webhook identifier.</param>
+    void ValidateWebhookId(string webhookId);
+
+    /// <summary>
+    /// Validates a webhook list request.
+    /// </summary>
+    /// <param name="request">The list request.</param>
+    void ValidateList(ListWebhooksRequest request);
+}

--- a/src/PublishingPlatform.SDK/Clients/WebhooksClient.cs
+++ b/src/PublishingPlatform.SDK/Clients/WebhooksClient.cs
@@ -1,14 +1,143 @@
+using System.Diagnostics;
+using System.Net.Http.Json;
 using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Clients.Webhooks.Requests;
+using PublishingPlatform.SDK.Clients.Webhooks.Serialization;
+using PublishingPlatform.SDK.Clients.Webhooks.Validation;
+using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Transport;
+using PublishingPlatform.SDK.Internal;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Models.Common;
 
 namespace PublishingPlatform.SDK.Clients;
 
+/// <summary>
+/// Orchestrates webhook management operations through the shared SDK transport.
+/// </summary>
 public sealed class WebhooksClient : IWebhooksClient
 {
+    private const string RegisterOperationName = "Webhooks.Register";
+    private const string UpdateOperationName = "Webhooks.Update";
+    private const string DeleteOperationName = "Webhooks.Delete";
+    private const string ListOperationName = "Webhooks.List";
+
     private readonly ISharedHttpTransport _transport;
+    private readonly IWebhookRequestValidator _validator;
+    private readonly IWebhookQueryStringBuilder _queryStringBuilder;
+    private readonly IWebhookRequestHeadersFactory _requestHeadersFactory;
+    private readonly IWebhookResponseReader _responseReader;
 
     internal WebhooksClient(ISharedHttpTransport transport)
+        : this(
+            transport,
+            new DefaultWebhookRequestValidator(),
+            new DefaultWebhookQueryStringBuilder(),
+            new DefaultWebhookRequestHeadersFactory(),
+            new DefaultWebhookResponseReader())
+    {
+    }
+
+    internal WebhooksClient(
+        ISharedHttpTransport transport,
+        IWebhookRequestValidator validator,
+        IWebhookQueryStringBuilder queryStringBuilder,
+        IWebhookRequestHeadersFactory requestHeadersFactory,
+        IWebhookResponseReader responseReader)
     {
         _transport = transport;
+        _validator = validator;
+        _queryStringBuilder = queryStringBuilder;
+        _requestHeadersFactory = requestHeadersFactory;
+        _responseReader = responseReader;
+    }
+
+    /// <inheritdoc />
+    public async Task<Webhook> RegisterAsync(
+        RegisterWebhookRequest request,
+        string? idempotencyKey = null,
+        CancellationToken cancellationToken = default)
+    {
+        Guards.NotNull(request, nameof(request));
+        _validator.ValidateRegister(request);
+
+        using var activity = StartActivity(RegisterOperationName);
+        var headers = _requestHeadersFactory.CreateIdempotencyHeaders(idempotencyKey);
+        var content = JsonContent.Create(request);
+        using var response = await _transport.SendAsync(
+            HttpMethod.Post,
+            "/webhooks",
+            content,
+            headers,
+            RegisterOperationName,
+            cancellationToken).ConfigureAwait(false);
+
+        return await _responseReader.ReadWebhookAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<Webhook> UpdateAsync(
+        UpdateWebhookRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        Guards.NotNull(request, nameof(request));
+        _validator.ValidateUpdate(request);
+
+        using var activity = StartActivity(UpdateOperationName);
+        var content = JsonContent.Create(request);
+        using var response = await _transport.SendAsync(
+            HttpMethod.Patch,
+            $"/webhooks/{Uri.EscapeDataString(request.WebhookId)}",
+            content,
+            null,
+            UpdateOperationName,
+            cancellationToken).ConfigureAwait(false);
+
+        return await _responseReader.ReadWebhookAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteAsync(
+        string webhookId,
+        CancellationToken cancellationToken = default)
+    {
+        _validator.ValidateWebhookId(webhookId);
+
+        using var activity = StartActivity(DeleteOperationName);
+        using var response = await _transport.SendAsync(
+            HttpMethod.Delete,
+            $"/webhooks/{Uri.EscapeDataString(webhookId)}",
+            null,
+            null,
+            DeleteOperationName,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<PagedResult<Webhook>> ListAsync(
+        ListWebhooksRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        Guards.NotNull(request, nameof(request));
+        _validator.ValidateList(request);
+
+        using var activity = StartActivity(ListOperationName);
+        var relativePath = _queryStringBuilder.BuildListPath(request);
+        using var response = await _transport.SendAsync(
+            HttpMethod.Get,
+            relativePath,
+            null,
+            null,
+            ListOperationName,
+            cancellationToken).ConfigureAwait(false);
+
+        return await _responseReader.ReadPagedWebhooksAsync(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static Activity? StartActivity(string operationName)
+    {
+        var activity = ActivitySourceProvider.ActivitySource.StartActivity(operationName, ActivityKind.Client);
+        activity?.SetTag("sdk.operation", operationName);
+        return activity;
     }
 }

--- a/src/PublishingPlatform.SDK/Models/ListWebhooksRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/ListWebhooksRequest.cs
@@ -1,0 +1,27 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents criteria for listing webhook registrations.
+/// </summary>
+public sealed class ListWebhooksRequest
+{
+    /// <summary>
+    /// Gets or sets the maximum number of webhooks to return.
+    /// </summary>
+    public int PageSize { get; set; } = 50;
+
+    /// <summary>
+    /// Gets or sets the continuation token for the next result page.
+    /// </summary>
+    public string? ContinuationToken { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional subscribed event filter.
+    /// </summary>
+    public string? Event { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional active-state filter.
+    /// </summary>
+    public bool? IsActive { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Models/Webhook.cs
+++ b/src/PublishingPlatform.SDK/Models/Webhook.cs
@@ -1,0 +1,42 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents a webhook registration that receives asynchronous platform event notifications.
+/// </summary>
+public sealed class Webhook
+{
+    /// <summary>
+    /// Gets or sets the webhook identifier.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the HTTPS callback endpoint URL.
+    /// </summary>
+    public string EndpointUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the subscribed event names.
+    /// </summary>
+    public IReadOnlyList<string> Events { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this webhook is active.
+    /// </summary>
+    public bool IsActive { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional signing key identifier managed outside the SDK.
+    /// </summary>
+    public string? SigningKeyId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the webhook creation timestamp.
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the webhook update timestamp.
+    /// </summary>
+    public DateTimeOffset? UpdatedAt { get; set; }
+}

--- a/tests/PublishingPlatform.SDK.Tests/Models/RequestModelContractsTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Models/RequestModelContractsTests.cs
@@ -69,6 +69,30 @@ public sealed class RequestModelContractsTests
     }
 
     [Fact]
+    public void ListWebhooksRequest_Defaults_AreSafe()
+    {
+        var request = new ListWebhooksRequest();
+
+        request.PageSize.Should().Be(50);
+        request.ContinuationToken.Should().BeNull();
+        request.Event.Should().BeNull();
+        request.IsActive.Should().BeNull();
+    }
+
+    [Fact]
+    public void Webhook_Defaults_AreSafe()
+    {
+        var webhook = new Webhook();
+
+        webhook.Id.Should().BeEmpty();
+        webhook.EndpointUrl.Should().BeEmpty();
+        webhook.Events.Should().BeEmpty();
+        webhook.IsActive.Should().BeFalse();
+        webhook.SigningKeyId.Should().BeNull();
+        webhook.UpdatedAt.Should().BeNull();
+    }
+
+    [Fact]
     public void BookAccessRevokeRequest_Defaults_AreSafe()
     {
         var request = new BookAccessRevokeRequest();

--- a/tests/PublishingPlatform.SDK.Tests/Webhooks/WebhooksClientTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Webhooks/WebhooksClientTests.cs
@@ -1,0 +1,359 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using Bogus;
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Clients.Webhooks.Requests;
+using PublishingPlatform.SDK.Clients.Webhooks.Serialization;
+using PublishingPlatform.SDK.Clients.Webhooks.Validation;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Infrastructure.Errors;
+using PublishingPlatform.SDK.Infrastructure.Transport;
+using PublishingPlatform.SDK.Internal.Resilience;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Models.Common;
+
+namespace PublishingPlatform.SDK.Tests.Webhooks;
+
+public sealed class WebhooksClientTests
+{
+    [Fact]
+    public async Task RegisterAsync_SendsPostWithIdempotencyHeaderAndCancellation()
+    {
+        Randomizer.Seed = new Random(56);
+        var token = new CancellationTokenSource().Token;
+        var request = CreateRegisterRequest();
+        var idempotencyKey = "webhook-registration-001";
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+            HttpMethod.Post,
+            "/webhooks",
+            Arg.Any<HttpContent>(),
+            Arg.Is<IReadOnlyDictionary<string, string>>(headers => headers["Idempotency-Key"] == idempotencyKey),
+            "Webhooks.Register",
+            token).Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = JsonContent.Create(CreateWebhook("whk-1")),
+            }));
+        var sut = new WebhooksClient(transport);
+
+        var result = await sut.RegisterAsync(request, idempotencyKey, token);
+
+        result.Id.Should().Be("whk-1");
+        await transport.Received(1).SendAsync(
+            HttpMethod.Post,
+            "/webhooks",
+            Arg.Any<HttpContent>(),
+            Arg.Is<IReadOnlyDictionary<string, string>>(headers => headers["Idempotency-Key"] == idempotencyKey),
+            "Webhooks.Register",
+            token);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SendsPatchWithEncodedWebhookId()
+    {
+        var request = new UpdateWebhookRequest
+        {
+            WebhookId = "whk 1/2",
+            EndpointUrl = "https://hooks.example.com/platform",
+            Events = ["book.published"],
+            IsActive = true,
+        };
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+            HttpMethod.Patch,
+            "/webhooks/whk%201%2F2",
+            Arg.Any<HttpContent>(),
+            null,
+            "Webhooks.Update",
+            Arg.Any<CancellationToken>()).Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(CreateWebhook("whk 1/2")),
+            }));
+        var sut = new WebhooksClient(transport);
+
+        var result = await sut.UpdateAsync(request);
+
+        result.Id.Should().Be("whk 1/2");
+        await transport.Received(1).SendAsync(
+            HttpMethod.Patch,
+            "/webhooks/whk%201%2F2",
+            Arg.Any<HttpContent>(),
+            null,
+            "Webhooks.Update",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteAsync_SendsDeleteWithEncodedWebhookId()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+            HttpMethod.Delete,
+            "/webhooks/whk%2B1%2F2",
+            null,
+            null,
+            "Webhooks.Delete",
+            Arg.Any<CancellationToken>()).Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent)));
+        var sut = new WebhooksClient(transport);
+
+        await sut.DeleteAsync("whk+1/2");
+
+        await transport.Received(1).SendAsync(
+            HttpMethod.Delete,
+            "/webhooks/whk%2B1%2F2",
+            null,
+            null,
+            "Webhooks.Delete",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListAsync_BuildsDeterministicEncodedQuery()
+    {
+        var request = new ListWebhooksRequest
+        {
+            PageSize = 25,
+            ContinuationToken = "ct+1/2",
+            Event = "book.published+distribution",
+            IsActive = true,
+        };
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+            HttpMethod.Get,
+            "/webhooks?pageSize=25&continuationToken=ct%2B1%2F2&event=book.published%2Bdistribution&isActive=true",
+            null,
+            null,
+            "Webhooks.List",
+            Arg.Any<CancellationToken>()).Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new PagedResult<Webhook>
+                {
+                    Items = [CreateWebhook("whk-list")],
+                    TotalCount = 1,
+                }),
+            }));
+        var sut = new WebhooksClient(transport);
+
+        var result = await sut.ListAsync(request);
+
+        result.Items.Should().ContainSingle();
+        await transport.Received(1).SendAsync(
+            HttpMethod.Get,
+            "/webhooks?pageSize=25&continuationToken=ct%2B1%2F2&event=book.published%2Bdistribution&isActive=true",
+            null,
+            null,
+            "Webhooks.List",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RegisterAsync_ThrowsArgumentNullException_ForNullRequest()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        var sut = new WebhooksClient(transport);
+
+        var act = async () => await sut.RegisterAsync(null!);
+
+        var ex = await act.Should().ThrowAsync<ArgumentNullException>();
+        ex.Which.ParamName.Should().Be("request");
+        await transport.DidNotReceiveWithAnyArgs().SendAsync(default!, default!, default, default, default!, default);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("http://hooks.example.com/platform")]
+    [InlineData("not-a-url")]
+    public async Task RegisterAsync_ThrowsBookValidationException_ForInvalidEndpointUrl(string endpointUrl)
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        var sut = new WebhooksClient(transport);
+        var request = CreateRegisterRequest();
+        request.EndpointUrl = endpointUrl;
+
+        var act = async () => await sut.RegisterAsync(request);
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Webhook endpoint URL");
+        await transport.DidNotReceiveWithAnyArgs().SendAsync(default!, default!, default, default, default!, default);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ThrowsBookValidationException_WhenEventsAreEmpty()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        var sut = new WebhooksClient(transport);
+
+        var act = async () => await sut.UpdateAsync(new UpdateWebhookRequest
+        {
+            WebhookId = "whk-1",
+            EndpointUrl = "https://hooks.example.com/platform",
+            Events = [],
+        });
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("At least one webhook event");
+        await transport.DidNotReceiveWithAnyArgs().SendAsync(default!, default!, default, default, default!, default);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(501)]
+    public async Task ListAsync_ThrowsBookValidationException_ForInvalidPageSize(int pageSize)
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        var sut = new WebhooksClient(transport);
+
+        var act = async () => await sut.ListAsync(new ListWebhooksRequest
+        {
+            PageSize = pageSize,
+        });
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("PageSize must be between 1 and 500");
+        await transport.DidNotReceiveWithAnyArgs().SendAsync(default!, default!, default, default, default!, default);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_ThrowsBookValidationException_WhenPayloadIsNull()
+    {
+        using var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, "application/json"),
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.test") };
+        var transport = new SharedHttpTransport(
+            client,
+            new NoOpPublishingPlatformResiliencePipeline(),
+            new FixedCorrelationIdProvider(),
+            new DefaultPublishingPlatformErrorMapper());
+        var sut = new WebhooksClient(transport);
+
+        var act = async () => await sut.RegisterAsync(CreateRegisterRequest());
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Webhook payload was empty");
+    }
+
+    [Fact]
+    public async Task ListAsync_ThrowsBookValidationException_WhenPagedPayloadIsNull()
+    {
+        using var handler = new SingleResponseHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, "application/json"),
+        });
+        using var client = new HttpClient(handler) { BaseAddress = new Uri("https://example.test") };
+        var transport = new SharedHttpTransport(
+            client,
+            new NoOpPublishingPlatformResiliencePipeline(),
+            new FixedCorrelationIdProvider(),
+            new DefaultPublishingPlatformErrorMapper());
+        var sut = new WebhooksClient(transport);
+
+        var act = async () => await sut.ListAsync(new ListWebhooksRequest());
+
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Paged webhooks payload was empty");
+    }
+
+    [Fact]
+    public void QueryStringBuilder_OmitsOptionalFilters_WhenMissing()
+    {
+        var builder = new DefaultWebhookQueryStringBuilder();
+
+        var path = builder.BuildListPath(new ListWebhooksRequest
+        {
+            PageSize = 50,
+            ContinuationToken = " ",
+            Event = null,
+        });
+
+        path.Should().Be("/webhooks?pageSize=50");
+    }
+
+    [Fact]
+    public void HeadersFactory_ReturnsNull_WhenIdempotencyKeyIsMissing()
+    {
+        var factory = new DefaultWebhookRequestHeadersFactory();
+
+        var headers = factory.CreateIdempotencyHeaders(" ");
+
+        headers.Should().BeNull();
+    }
+
+    [Fact]
+    public void Validator_ThrowsBookValidationException_WhenWebhookIdIsMissing()
+    {
+        var validator = new DefaultWebhookRequestValidator();
+
+        Action act = () => validator.ValidateWebhookId(" ");
+
+        var ex = act.Should().Throw<BookValidationException>();
+        ex.Which.Message.Should().Contain("Webhook id is required");
+    }
+
+    [Fact]
+    public void Validator_ThrowsBookValidationException_WhenEventIsWhitespace()
+    {
+        var validator = new DefaultWebhookRequestValidator();
+
+        Action act = () => validator.ValidateRegister(new RegisterWebhookRequest
+        {
+            EndpointUrl = "https://hooks.example.com/platform",
+            Events = ["book.published", " "],
+        });
+
+        var ex = act.Should().Throw<BookValidationException>();
+        ex.Which.Message.Should().Contain("Webhook events cannot contain empty values");
+    }
+
+    private static RegisterWebhookRequest CreateRegisterRequest()
+    {
+        var faker = new Faker();
+
+        return new RegisterWebhookRequest
+        {
+            EndpointUrl = "https://hooks.example.com/publishing-platform",
+            Events = [$"book.{faker.Hacker.Verb()}", $"book.{faker.Hacker.Verb()}"],
+            IsActive = true,
+            SigningKeyId = "signing-key-01",
+        };
+    }
+
+    private static Webhook CreateWebhook(string id)
+    {
+        return new Webhook
+        {
+            Id = id,
+            EndpointUrl = "https://hooks.example.com/publishing-platform",
+            Events = ["book.published"],
+            IsActive = true,
+            SigningKeyId = "signing-key-01",
+            CreatedAt = DateTimeOffset.UtcNow,
+        };
+    }
+
+    private sealed class SingleResponseHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+
+        public SingleResponseHandler(HttpResponseMessage response)
+        {
+            _response = response;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_response);
+        }
+    }
+
+    private sealed class FixedCorrelationIdProvider : ICorrelationIdProvider
+    {
+        public string Create()
+        {
+            return Guid.NewGuid().ToString("N");
+        }
+    }
+}


### PR DESCRIPTION
# Summary

Implement the `IWebhooksClient` module for RPS-56 so SDK consumers can manage webhook callback registrations through the existing root client.

What changed:

- Added public webhook management operations for register, update, delete, and list flows.
- Added public `Webhook` and `ListWebhooksRequest` models for webhook snapshots and list filtering.
- Implemented the concrete `WebhooksClient` using the shared transport, HTTPS endpoint validation, idempotency support for registration, deterministic query construction, and typed response readers.
- Added focused webhook collaborators for validation, query serialization, response reading, and idempotency headers.
- Updated README usage documentation and added a Webhooks example script.

API impact:

- `IWebhooksClient` now exposes public methods for webhook management.
- New public model types: `Webhook` and `ListWebhooksRequest`.
- Existing `IPublishingPlatformClient.Webhooks` accessor remains unchanged and now resolves an operational module.

# Validation

- [x] `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal`
- [x] Added webhook client tests for register, update, delete, list, validation failures, encoded routes/query strings, idempotency headers, and null response payload handling
- [x] Added collaborator seam tests for validator, query builder, headers factory, and response reader behavior
- [x] Added model contract tests for webhook model and list request defaults

Test result evidence:

- Passed: 203
- Failed: 0
- Skipped: 0

# Release Please Override (Required for releasable changes)

```text
BEGIN_COMMIT_OVERRIDE
feat(webhooks): implement webhook management client
END_COMMIT_OVERRIDE
```

# Manual NuGet Publish

1. Confirm `Directory.Build.props` version equals intended release version.
2. Create matching tag `v<version>` on that exact commit.
3. Run `Publish NuGet` workflow manually with that tag.
4. Verify package version appears on NuGet.
