### PR TITLE
RPS-11 feat!: Add centralized, opt-in diagnostics and observability for the Publishing Platform SDK.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.1.2</Version>
+    <Version>0.2.0</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.1.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Polly.Core" Version="8.5.2" />
     <PackageVersion Include="xunit" Version="2.9.2" />

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Runnable scripts are available in:
 
 - `examples/BasicUsage/BuilderInitializationExample.csx`
 - `examples/BasicUsage/DiInitializationExample.csx`
+- `examples/Diagnostics/README.md`
 - `examples/BookPublishing/BookPublishingExample.csx`
 - `examples/BookDistribution/BookDistributionExample.csx`
 - `examples/BookAnalytics/BookAnalyticsExample.csx`

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,3 +1,64 @@
-﻿# diagnostics
+# Diagnostics
 
-_TODO: add content._
+The SDK diagnostics layer provides opt-in logging, tracing, metrics, and correlation IDs through shared transport infrastructure. Module clients pass operation metadata to the shared transport; diagnostics behavior is resolved centrally from global and per-module options.
+
+## Safe Defaults
+
+Diagnostics are disabled by default except correlation ID generation. The SDK never logs API keys, bearer tokens, auth headers, idempotency keys, request bodies, response bodies, or uploaded content unless a future consumer explicitly enables body logging and accepts that risk.
+
+```csharp
+var options = new PublishingPlatformClientOptions
+{
+    BaseUrl = "https://api.books.example",
+    ApiKey = "from-secure-configuration",
+    Diagnostics = new DiagnosticsOptions
+    {
+        EnableLogging = true,
+        EnableTracing = true,
+        EnableMetrics = true
+    }
+};
+```
+
+## Per-Module Overrides
+
+Global diagnostics settings apply to all modules. A module override changes only the values explicitly set on that module.
+
+```csharp
+options.Diagnostics = new DiagnosticsOptions
+{
+    EnableLogging = true,
+    EnableTracing = false
+};
+
+options.BookContentDiagnostics = new ModuleDiagnosticsOptions
+{
+    EnableTracing = true
+};
+
+options.BookAnalyticsDiagnostics = new ModuleDiagnosticsOptions
+{
+    EnableLogging = false
+};
+```
+
+Supported module override properties are `BooksDiagnostics`, `BookContentDiagnostics`, `BookPublishingDiagnostics`, `BookDistributionDiagnostics`, `BookAccessDiagnostics`, `BookAnalyticsDiagnostics`, `BookAuditLogsDiagnostics`, and `WebhooksDiagnostics`.
+
+## Correlation
+
+Outgoing SDK requests use `X-Correlation-Id` by default. The SDK preserves a caller-provided correlation header and otherwise generates one when `GenerateCorrelationIds` is enabled.
+
+The resolved correlation ID is added to:
+
+- HTTP request headers
+- activity tags as `correlation.id`
+- structured log fields when logging is enabled
+- SDK error context when an HTTP failure is mapped to an SDK exception
+
+Use `DiagnosticsOptions.CorrelationHeaderName` to align with an existing platform convention.
+
+## OpenTelemetry Compatibility
+
+Tracing uses `System.Diagnostics.ActivitySource` named `PublishingPlatform.SDK`.
+
+Metrics use `System.Diagnostics.Metrics.Meter` named `PublishingPlatform.SDK` and record request count, failure count, request duration, and retry count. Consumers can collect these signals with OpenTelemetry or any listener that supports the built-in .NET diagnostics APIs.

--- a/examples/Diagnostics/README.md
+++ b/examples/Diagnostics/README.md
@@ -1,3 +1,34 @@
-﻿# Diagnostics
+# Diagnostics
 
-_TODO: add example._
+Diagnostics are opt-in and safe by default.
+
+```csharp
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Infrastructure.Diagnostics;
+using PublishingPlatform.SDK.Options;
+
+var options = new PublishingPlatformClientOptions
+{
+    BaseUrl = "https://api.books.example",
+    ApiKey = Environment.GetEnvironmentVariable("PUBLISHING_PLATFORM_API_KEY") ?? string.Empty,
+    Diagnostics = new DiagnosticsOptions
+    {
+        EnableLogging = true,
+        EnableTracing = true,
+        EnableMetrics = true
+    },
+    BookContentDiagnostics = new ModuleDiagnosticsOptions
+    {
+        EnableTracing = true
+    },
+    BookAnalyticsDiagnostics = new ModuleDiagnosticsOptions
+    {
+        EnableLogging = false
+    }
+};
+
+var client = PublishingPlatformClientBuilder.Create(options).Build();
+var book = await client.Books.GetByIdAsync("book-123");
+```
+
+The SDK adds a correlation ID header to outgoing requests and attaches the same value to Activity tags and logs when diagnostics are enabled. Request and response bodies, API keys, bearer tokens, idempotency keys, and uploaded file content are not logged by default.

--- a/src/PublishingPlatform.SDK/Clients/BookAccessClient.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAccessClient.cs
@@ -1,10 +1,8 @@
-using System.Diagnostics;
 using System.Net.Http.Json;
 using PublishingPlatform.SDK.Abstractions;
 using PublishingPlatform.SDK.Clients.Common.Pagination;
 using PublishingPlatform.SDK.Clients.BookAccess.Serialization;
 using PublishingPlatform.SDK.Clients.BookAccess.Validation;
-using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Transport;
 using PublishingPlatform.SDK.Internal;
 using PublishingPlatform.SDK.Models;
@@ -17,6 +15,11 @@ namespace PublishingPlatform.SDK.Clients;
 /// </summary>
 public sealed class BookAccessClient : IBookAccessClient
 {
+    private const string GrantOperationName = "BookAccess.Grant";
+    private const string RevokeOperationName = "BookAccess.Revoke";
+    private const string CheckOperationName = "BookAccess.Check";
+    private const string ListOperationName = "BookAccess.List";
+
     private readonly ISharedHttpTransport _transport;
     private readonly IBookAccessRequestValidator _validator;
     private readonly IBookAccessQueryStringBuilder _queryStringBuilder;
@@ -51,7 +54,6 @@ public sealed class BookAccessClient : IBookAccessClient
         Guards.NotNull(request, nameof(request));
         _validator.ValidateGrant(request);
 
-        using var activity = StartActivity("BookAccess.Grant");
         var content = JsonContent.Create(request);
         var relativePath = $"/books/{Uri.EscapeDataString(request.BookId)}/access";
         using var response = await _transport.SendAsync(
@@ -59,7 +61,7 @@ public sealed class BookAccessClient : IBookAccessClient
             relativePath,
             content,
             null,
-            "BookAccess.Grant",
+            GrantOperationName,
             cancellationToken).ConfigureAwait(false);
 
         return await _responseReader.ReadGrantResultAsync(response, cancellationToken).ConfigureAwait(false);
@@ -73,7 +75,6 @@ public sealed class BookAccessClient : IBookAccessClient
         Guards.NotNull(request, nameof(request));
         _validator.ValidateRevoke(request);
 
-        using var activity = StartActivity("BookAccess.Revoke");
         var content = JsonContent.Create(request);
         var relativePath = $"/books/{Uri.EscapeDataString(request.BookId)}/access/revoke";
         using var response = await _transport.SendAsync(
@@ -81,7 +82,7 @@ public sealed class BookAccessClient : IBookAccessClient
             relativePath,
             content,
             null,
-            "BookAccess.Revoke",
+            RevokeOperationName,
             cancellationToken).ConfigureAwait(false);
 
         return await _responseReader.ReadRevokeResultAsync(response, cancellationToken).ConfigureAwait(false);
@@ -95,14 +96,13 @@ public sealed class BookAccessClient : IBookAccessClient
         Guards.NotNull(request, nameof(request));
         _validator.ValidateCheck(request);
 
-        using var activity = StartActivity("BookAccess.Check");
         var relativePath = _queryStringBuilder.BuildCheckPath(request);
         using var response = await _transport.SendAsync(
             HttpMethod.Get,
             relativePath,
             null,
             null,
-            "BookAccess.Check",
+            CheckOperationName,
             cancellationToken).ConfigureAwait(false);
 
         return await _responseReader.ReadStatusAsync(response, cancellationToken).ConfigureAwait(false);
@@ -116,14 +116,13 @@ public sealed class BookAccessClient : IBookAccessClient
         Guards.NotNull(request, nameof(request));
         _validator.ValidateList(request);
 
-        using var activity = StartActivity("BookAccess.List");
         var relativePath = _queryStringBuilder.BuildListPath(request);
         using var response = await _transport.SendAsync(
             HttpMethod.Get,
             relativePath,
             null,
             null,
-            "BookAccess.List",
+            ListOperationName,
             cancellationToken).ConfigureAwait(false);
 
         return await _responseReader.ReadPagedGrantResultAsync(response, cancellationToken).ConfigureAwait(false);
@@ -143,13 +142,6 @@ public sealed class BookAccessClient : IBookAccessClient
             static (iterationRequest, continuationToken) => iterationRequest.ContinuationToken = continuationToken,
             ListAsync,
             cancellationToken);
-    }
-
-    private static Activity? StartActivity(string operationName)
-    {
-        var activity = ActivitySourceProvider.ActivitySource.StartActivity(operationName, ActivityKind.Client);
-        activity?.SetTag("sdk.operation", operationName);
-        return activity;
     }
 
     private static ListBookAccessRequest CloneListRequest(ListBookAccessRequest request)

--- a/src/PublishingPlatform.SDK/Clients/BookAnalyticsClient.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAnalyticsClient.cs
@@ -1,8 +1,6 @@
-using System.Diagnostics;
 using PublishingPlatform.SDK.Abstractions;
 using PublishingPlatform.SDK.Clients.BookAnalytics.Serialization;
 using PublishingPlatform.SDK.Clients.BookAnalytics.Validation;
-using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Transport;
 using PublishingPlatform.SDK.Internal;
 using PublishingPlatform.SDK.Models;
@@ -14,6 +12,8 @@ namespace PublishingPlatform.SDK.Clients;
 /// </summary>
 public sealed class BookAnalyticsClient : IBookAnalyticsClient
 {
+    private const string GetSummaryOperationName = "BookAnalytics.GetSummary";
+
     private readonly ISharedHttpTransport _transport;
     private readonly IBookAnalyticsRequestValidator _validator;
     private readonly IBookAnalyticsQueryStringBuilder _queryStringBuilder;
@@ -48,23 +48,15 @@ public sealed class BookAnalyticsClient : IBookAnalyticsClient
         Guards.NotNull(request, nameof(request));
         _validator.ValidateGetSummary(request);
 
-        using var activity = StartActivity("BookAnalytics.GetSummary");
         var relativePath = _queryStringBuilder.BuildSummaryPath(request);
         using var response = await _transport.SendAsync(
             HttpMethod.Get,
             relativePath,
             null,
             null,
-            "BookAnalytics.GetSummary",
+            GetSummaryOperationName,
             cancellationToken).ConfigureAwait(false);
 
         return await _responseReader.ReadSummaryAsync(response, cancellationToken).ConfigureAwait(false);
-    }
-
-    private static Activity? StartActivity(string operationName)
-    {
-        var activity = ActivitySourceProvider.ActivitySource.StartActivity(operationName, ActivityKind.Client);
-        activity?.SetTag("sdk.operation", operationName);
-        return activity;
     }
 }

--- a/src/PublishingPlatform.SDK/Clients/BookAuditLogsClient.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookAuditLogsClient.cs
@@ -1,9 +1,7 @@
-using System.Diagnostics;
 using PublishingPlatform.SDK.Abstractions;
 using PublishingPlatform.SDK.Clients.Common.Pagination;
 using PublishingPlatform.SDK.Clients.BookAuditLogs.Serialization;
 using PublishingPlatform.SDK.Clients.BookAuditLogs.Validation;
-using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Transport;
 using PublishingPlatform.SDK.Internal;
 using PublishingPlatform.SDK.Models;
@@ -51,7 +49,6 @@ public sealed class BookAuditLogsClient : IBookAuditLogsClient
         Guards.NotNull(request, nameof(request));
         _validator.ValidateList(request);
 
-        using var activity = StartActivity(ListOperationName);
         var relativePath = _queryStringBuilder.BuildListPath(request);
         using var response = await _transport.SendAsync(
             HttpMethod.Get,
@@ -82,13 +79,6 @@ public sealed class BookAuditLogsClient : IBookAuditLogsClient
             },
             ListAsync,
             cancellationToken);
-    }
-
-    private static Activity? StartActivity(string operationName)
-    {
-        var activity = ActivitySourceProvider.ActivitySource.StartActivity(operationName, ActivityKind.Client);
-        activity?.SetTag("sdk.operation", operationName);
-        return activity;
     }
 
     private static ListBookAuditLogsRequest CloneListRequest(ListBookAuditLogsRequest request)

--- a/src/PublishingPlatform.SDK/Clients/BookContentClient.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookContentClient.cs
@@ -1,9 +1,7 @@
-using System.Diagnostics;
 using PublishingPlatform.SDK.Abstractions;
 using PublishingPlatform.SDK.Clients.BookContent.Requests;
 using PublishingPlatform.SDK.Clients.BookContent.Serialization;
 using PublishingPlatform.SDK.Clients.BookContent.Validation;
-using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Transport;
 using PublishingPlatform.SDK.Internal;
 using PublishingPlatform.SDK.Models;
@@ -16,6 +14,9 @@ namespace PublishingPlatform.SDK.Clients;
 /// </summary>
 public sealed class BookContentClient : IBookContentClient
 {
+    private const string GetOperationName = "BookContent.Get";
+    private const string UploadOrReplaceOperationName = "BookContent.UploadOrReplace";
+
     private readonly ISharedHttpTransport _transport;
     private readonly IBookContentRequestValidator _validator;
     private readonly IBookContentRequestHeadersFactory _requestHeadersFactory;
@@ -51,13 +52,12 @@ public sealed class BookContentClient : IBookContentClient
     {
         _validator.ValidateBookId(bookId);
 
-        using var activity = StartActivity("BookContent.Get");
         using var response = await _transport.SendAsync(
             HttpMethod.Get,
             $"/books/{Uri.EscapeDataString(bookId)}/content",
             null,
             null,
-            "BookContent.Get",
+            GetOperationName,
             ct).ConfigureAwait(false);
 
         return await _responseReader.ReadBookContentAsync(response, ct).ConfigureAwait(false);
@@ -70,7 +70,6 @@ public sealed class BookContentClient : IBookContentClient
         Guards.NotNull(request, nameof(request));
         _validator.ValidateUploadRequest(request);
 
-        using var activity = StartActivity("BookContent.UploadOrReplace");
         var headers = _requestHeadersFactory.CreateIdempotencyHeaders(request.IdempotencyKey);
         using var content = _multipartFormFactory.Create(request);
         using var response = await _transport.SendAsync(
@@ -78,16 +77,9 @@ public sealed class BookContentClient : IBookContentClient
             $"/books/{Uri.EscapeDataString(bookId)}/content",
             content,
             headers,
-            "BookContent.UploadOrReplace",
+            UploadOrReplaceOperationName,
             ct).ConfigureAwait(false);
 
         return await _responseReader.ReadBookContentAsync(response, ct).ConfigureAwait(false);
-    }
-
-    private static Activity? StartActivity(string operationName)
-    {
-        var activity = ActivitySourceProvider.ActivitySource.StartActivity(operationName, ActivityKind.Client);
-        activity?.SetTag("sdk.operation", operationName);
-        return activity;
     }
 }

--- a/src/PublishingPlatform.SDK/Clients/BookDistributionClient.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookDistributionClient.cs
@@ -1,10 +1,8 @@
-using System.Diagnostics;
 using System.Net.Http.Json;
 using PublishingPlatform.SDK.Abstractions;
 using PublishingPlatform.SDK.Clients.BookDistribution.Requests;
 using PublishingPlatform.SDK.Clients.BookDistribution.Serialization;
 using PublishingPlatform.SDK.Clients.BookDistribution.Validation;
-using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Transport;
 using PublishingPlatform.SDK.Internal;
 using PublishingPlatform.SDK.Models;
@@ -54,7 +52,6 @@ public sealed class BookDistributionClient : IBookDistributionClient
         Guards.NotNull(request, nameof(request));
         _validator.ValidateStartRequest(request);
 
-        using var activity = StartActivity(StartOperationName);
         var headers = _requestHeadersFactory.CreateIdempotencyHeaders(idempotencyKey);
         var content = JsonContent.Create(request);
         using var response = await _transport.SendAsync(
@@ -74,7 +71,6 @@ public sealed class BookDistributionClient : IBookDistributionClient
         _validator.ValidateBookId(bookId);
         _validator.ValidateOperationId(operationId);
 
-        using var activity = StartActivity(GetStatusOperationName);
         using var response = await _transport.SendAsync(
             HttpMethod.Get,
             $"/books/{Uri.EscapeDataString(bookId)}/distribution/{Uri.EscapeDataString(operationId)}/status",
@@ -92,7 +88,6 @@ public sealed class BookDistributionClient : IBookDistributionClient
         _validator.ValidateBookId(bookId);
         _validator.ValidateOperationId(operationId);
 
-        using var activity = StartActivity(RetryOperationName);
         var headers = _requestHeadersFactory.CreateIdempotencyHeaders(idempotencyKey);
         using var response = await _transport.SendAsync(
             HttpMethod.Post,
@@ -110,7 +105,6 @@ public sealed class BookDistributionClient : IBookDistributionClient
     {
         _validator.ValidateBookId(bookId);
 
-        using var activity = StartActivity(ListOperationName);
         using var response = await _transport.SendAsync(
             HttpMethod.Get,
             $"/books/{Uri.EscapeDataString(bookId)}/distribution",
@@ -120,12 +114,5 @@ public sealed class BookDistributionClient : IBookDistributionClient
             ct).ConfigureAwait(false);
 
         return await _responseReader.ReadListAsync(response, ct).ConfigureAwait(false);
-    }
-
-    private static Activity? StartActivity(string operationName)
-    {
-        var activity = ActivitySourceProvider.ActivitySource.StartActivity(operationName, ActivityKind.Client);
-        activity?.SetTag("sdk.operation", operationName);
-        return activity;
     }
 }

--- a/src/PublishingPlatform.SDK/Clients/BookPublishingClient.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookPublishingClient.cs
@@ -1,10 +1,8 @@
-using System.Diagnostics;
 using System.Net.Http.Json;
 using PublishingPlatform.SDK.Abstractions;
 using PublishingPlatform.SDK.Clients.BookPublishing.Requests;
 using PublishingPlatform.SDK.Clients.BookPublishing.Serialization;
 using PublishingPlatform.SDK.Clients.BookPublishing.Validation;
-using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Transport;
 using PublishingPlatform.SDK.Internal;
 using PublishingPlatform.SDK.Models;
@@ -16,6 +14,11 @@ namespace PublishingPlatform.SDK.Clients;
 /// </summary>
 public sealed class BookPublishingClient : IBookPublishingClient
 {
+    private const string PublishOperationName = "BookPublishing.Publish";
+    private const string UnpublishOperationName = "BookPublishing.Unpublish";
+    private const string ScheduleOperationName = "BookPublishing.Schedule";
+    private const string GetStatusOperationName = "BookPublishing.GetStatus";
+
     private readonly ISharedHttpTransport _transport;
     private readonly IBookPublishingRequestValidator _validator;
     private readonly IBookPublishingRequestHeadersFactory _requestHeadersFactory;
@@ -49,7 +52,6 @@ public sealed class BookPublishingClient : IBookPublishingClient
         Guards.NotNull(request, nameof(request));
         _validator.ValidatePublish(request);
 
-        using var activity = StartActivity("BookPublishing.Publish");
         var headers = _requestHeadersFactory.CreateIdempotencyHeaders(idempotencyKey);
         var content = JsonContent.Create(request);
         using var response = await _transport.SendAsync(
@@ -57,7 +59,7 @@ public sealed class BookPublishingClient : IBookPublishingClient
             $"/books/{Uri.EscapeDataString(bookId)}/publishing/publish",
             content,
             headers,
-            "BookPublishing.Publish",
+            PublishOperationName,
             ct).ConfigureAwait(false);
 
         return await _responseReader.ReadStatusAsync(response, ct).ConfigureAwait(false);
@@ -68,14 +70,13 @@ public sealed class BookPublishingClient : IBookPublishingClient
     {
         _validator.ValidateBookId(bookId);
 
-        using var activity = StartActivity("BookPublishing.Unpublish");
         var headers = _requestHeadersFactory.CreateIdempotencyHeaders(idempotencyKey);
         using var response = await _transport.SendAsync(
             HttpMethod.Post,
             $"/books/{Uri.EscapeDataString(bookId)}/publishing/unpublish",
             null,
             headers,
-            "BookPublishing.Unpublish",
+            UnpublishOperationName,
             ct).ConfigureAwait(false);
 
         return await _responseReader.ReadStatusAsync(response, ct).ConfigureAwait(false);
@@ -88,7 +89,6 @@ public sealed class BookPublishingClient : IBookPublishingClient
         Guards.NotNull(request, nameof(request));
         _validator.ValidateSchedule(request);
 
-        using var activity = StartActivity("BookPublishing.Schedule");
         var headers = _requestHeadersFactory.CreateIdempotencyHeaders(idempotencyKey);
         var content = JsonContent.Create(request);
         using var response = await _transport.SendAsync(
@@ -96,7 +96,7 @@ public sealed class BookPublishingClient : IBookPublishingClient
             $"/books/{Uri.EscapeDataString(bookId)}/publishing/schedule",
             content,
             headers,
-            "BookPublishing.Schedule",
+            ScheduleOperationName,
             ct).ConfigureAwait(false);
 
         return await _responseReader.ReadStatusAsync(response, ct).ConfigureAwait(false);
@@ -107,22 +107,14 @@ public sealed class BookPublishingClient : IBookPublishingClient
     {
         _validator.ValidateBookId(bookId);
 
-        using var activity = StartActivity("BookPublishing.GetStatus");
         using var response = await _transport.SendAsync(
             HttpMethod.Get,
             $"/books/{Uri.EscapeDataString(bookId)}/publishing/status",
             null,
             null,
-            "BookPublishing.GetStatus",
+            GetStatusOperationName,
             ct).ConfigureAwait(false);
 
         return await _responseReader.ReadStatusAsync(response, ct).ConfigureAwait(false);
-    }
-
-    private static Activity? StartActivity(string operationName)
-    {
-        var activity = ActivitySourceProvider.ActivitySource.StartActivity(operationName, ActivityKind.Client);
-        activity?.SetTag("sdk.operation", operationName);
-        return activity;
     }
 }

--- a/src/PublishingPlatform.SDK/Clients/BooksClient.cs
+++ b/src/PublishingPlatform.SDK/Clients/BooksClient.cs
@@ -1,11 +1,9 @@
-using System.Diagnostics;
 using System.Net.Http.Json;
 using PublishingPlatform.SDK.Abstractions;
 using PublishingPlatform.SDK.Clients.Common.Pagination;
 using PublishingPlatform.SDK.Clients.Books.Requests;
 using PublishingPlatform.SDK.Clients.Books.Serialization;
 using PublishingPlatform.SDK.Clients.Books.Validation;
-using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Transport;
 using PublishingPlatform.SDK.Internal;
 using PublishingPlatform.SDK.Models;
@@ -18,6 +16,13 @@ namespace PublishingPlatform.SDK.Clients;
 /// </summary>
 public sealed class BooksClient : IBooksClient
 {
+    private const string CreateOperationName = "Books.Create";
+    private const string GetByIdOperationName = "Books.GetById";
+    private const string ListOperationName = "Books.List";
+    private const string UpdateMetadataOperationName = "Books.UpdateMetadata";
+    private const string PatchMetadataOperationName = "Books.PatchMetadata";
+    private const string DeleteOperationName = "Books.Delete";
+
     private readonly ISharedHttpTransport _transport;
     private readonly IBookRequestValidator _validator;
     private readonly IBookQueryStringBuilder _queryStringBuilder;
@@ -54,10 +59,9 @@ public sealed class BooksClient : IBooksClient
         Guards.NotNull(request, nameof(request));
         _validator.ValidateCreate(request);
 
-        using var activity = StartActivity("Books.Create");
         var headers = _requestHeadersFactory.CreateIdempotencyHeaders(request.IdempotencyKey);
         var content = JsonContent.Create(request);
-        using var response = await _transport.SendAsync(HttpMethod.Post, "/books", content, headers, "Books.Create", ct).ConfigureAwait(false);
+        using var response = await _transport.SendAsync(HttpMethod.Post, "/books", content, headers, CreateOperationName, ct).ConfigureAwait(false);
 
         return await _responseReader.ReadBookAsync(response, ct).ConfigureAwait(false);
     }
@@ -66,8 +70,7 @@ public sealed class BooksClient : IBooksClient
     public async Task<Book> GetByIdAsync(string bookId, CancellationToken ct = default)
     {
         _validator.ValidateBookId(bookId);
-        using var activity = StartActivity("Books.GetById");
-        using var response = await _transport.SendAsync(HttpMethod.Get, $"/books/{Uri.EscapeDataString(bookId)}", null, null, "Books.GetById", ct).ConfigureAwait(false);
+        using var response = await _transport.SendAsync(HttpMethod.Get, $"/books/{Uri.EscapeDataString(bookId)}", null, null, GetByIdOperationName, ct).ConfigureAwait(false);
         return await _responseReader.ReadBookAsync(response, ct).ConfigureAwait(false);
     }
 
@@ -77,9 +80,8 @@ public sealed class BooksClient : IBooksClient
         Guards.NotNull(request, nameof(request));
         _validator.ValidateList(request);
 
-        using var activity = StartActivity("Books.List");
         var relativePath = _queryStringBuilder.BuildListPath(request);
-        using var response = await _transport.SendAsync(HttpMethod.Get, relativePath, null, null, "Books.List", ct).ConfigureAwait(false);
+        using var response = await _transport.SendAsync(HttpMethod.Get, relativePath, null, null, ListOperationName, ct).ConfigureAwait(false);
         return await _responseReader.ReadPagedResultAsync(response, ct).ConfigureAwait(false);
     }
 
@@ -108,10 +110,9 @@ public sealed class BooksClient : IBooksClient
         Guards.NotNull(request, nameof(request));
         _validator.ValidateUpdate(request);
 
-        using var activity = StartActivity("Books.UpdateMetadata");
         var headers = _requestHeadersFactory.CreateConcurrencyHeaders(request.ConcurrencyToken);
         var content = JsonContent.Create(request);
-        using var response = await _transport.SendAsync(HttpMethod.Put, $"/books/{Uri.EscapeDataString(bookId)}", content, headers, "Books.UpdateMetadata", ct).ConfigureAwait(false);
+        using var response = await _transport.SendAsync(HttpMethod.Put, $"/books/{Uri.EscapeDataString(bookId)}", content, headers, UpdateMetadataOperationName, ct).ConfigureAwait(false);
         return await _responseReader.ReadBookAsync(response, ct).ConfigureAwait(false);
     }
 
@@ -122,10 +123,9 @@ public sealed class BooksClient : IBooksClient
         Guards.NotNull(request, nameof(request));
         _validator.ValidatePatch(request);
 
-        using var activity = StartActivity("Books.PatchMetadata");
         var headers = _requestHeadersFactory.CreateConcurrencyHeaders(request.ConcurrencyToken);
         var content = JsonContent.Create(request);
-        using var response = await _transport.SendAsync(HttpMethod.Patch, $"/books/{Uri.EscapeDataString(bookId)}", content, headers, "Books.PatchMetadata", ct).ConfigureAwait(false);
+        using var response = await _transport.SendAsync(HttpMethod.Patch, $"/books/{Uri.EscapeDataString(bookId)}", content, headers, PatchMetadataOperationName, ct).ConfigureAwait(false);
         return await _responseReader.ReadBookAsync(response, ct).ConfigureAwait(false);
     }
 
@@ -133,15 +133,7 @@ public sealed class BooksClient : IBooksClient
     public async Task DeleteAsync(string bookId, CancellationToken ct = default)
     {
         _validator.ValidateBookId(bookId);
-        using var activity = StartActivity("Books.Delete");
-        using var _ = await _transport.SendAsync(HttpMethod.Delete, $"/books/{Uri.EscapeDataString(bookId)}", null, null, "Books.Delete", ct).ConfigureAwait(false);
-    }
-
-    private static Activity? StartActivity(string operationName)
-    {
-        var activity = ActivitySourceProvider.ActivitySource.StartActivity(operationName, ActivityKind.Client);
-        activity?.SetTag("sdk.operation", operationName);
-        return activity;
+        using var _ = await _transport.SendAsync(HttpMethod.Delete, $"/books/{Uri.EscapeDataString(bookId)}", null, null, DeleteOperationName, ct).ConfigureAwait(false);
     }
 
     private static ListBooksRequest CloneListRequest(ListBooksRequest request)

--- a/src/PublishingPlatform.SDK/Clients/PublishingPlatformClientBuilder.cs
+++ b/src/PublishingPlatform.SDK/Clients/PublishingPlatformClientBuilder.cs
@@ -1,4 +1,5 @@
 using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Errors;
 using PublishingPlatform.SDK.Infrastructure.Transport;
 using PublishingPlatform.SDK.Internal.Resilience;
@@ -42,7 +43,13 @@ public sealed class PublishingPlatformClientBuilder
         var httpClient = SdkHttpClientResolver.Resolve(serviceProvider);
         var pipeline = _customPipeline ?? ResiliencePipelineFactory.Create(_options.Resilience);
         var errorMapper = _customErrorMapper ?? _options.ErrorMapper ?? new DefaultPublishingPlatformErrorMapper();
-        var transport = new SharedHttpTransport(httpClient, pipeline, new GuidCorrelationIdProvider(), errorMapper);
+        var transport = SharedHttpTransportBuilder.Create()
+            .WithHttpClient(httpClient)
+            .WithResiliencePipeline(pipeline)
+            .WithCorrelationProvider(new GuidCorrelationIdProvider())
+            .WithErrorMapper(errorMapper)
+            .WithDiagnosticsOptionsResolver(new DefaultDiagnosticsOptionsResolver(_options))
+            .Build();
 
         return PublishingPlatformClient.CreateFromTransport(transport);
     }

--- a/src/PublishingPlatform.SDK/Clients/WebhooksClient.cs
+++ b/src/PublishingPlatform.SDK/Clients/WebhooksClient.cs
@@ -1,11 +1,9 @@
-using System.Diagnostics;
 using System.Net.Http.Json;
 using PublishingPlatform.SDK.Abstractions;
 using PublishingPlatform.SDK.Clients.Common.Pagination;
 using PublishingPlatform.SDK.Clients.Webhooks.Requests;
 using PublishingPlatform.SDK.Clients.Webhooks.Serialization;
 using PublishingPlatform.SDK.Clients.Webhooks.Validation;
-using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Transport;
 using PublishingPlatform.SDK.Internal;
 using PublishingPlatform.SDK.Models;
@@ -62,7 +60,6 @@ public sealed class WebhooksClient : IWebhooksClient
         Guards.NotNull(request, nameof(request));
         _validator.ValidateRegister(request);
 
-        using var activity = StartActivity(RegisterOperationName);
         var headers = _requestHeadersFactory.CreateIdempotencyHeaders(idempotencyKey);
         var content = JsonContent.Create(request);
         using var response = await _transport.SendAsync(
@@ -84,7 +81,6 @@ public sealed class WebhooksClient : IWebhooksClient
         Guards.NotNull(request, nameof(request));
         _validator.ValidateUpdate(request);
 
-        using var activity = StartActivity(UpdateOperationName);
         var content = JsonContent.Create(request);
         using var response = await _transport.SendAsync(
             HttpMethod.Patch,
@@ -104,7 +100,6 @@ public sealed class WebhooksClient : IWebhooksClient
     {
         _validator.ValidateWebhookId(webhookId);
 
-        using var activity = StartActivity(DeleteOperationName);
         using var response = await _transport.SendAsync(
             HttpMethod.Delete,
             $"/webhooks/{Uri.EscapeDataString(webhookId)}",
@@ -122,7 +117,6 @@ public sealed class WebhooksClient : IWebhooksClient
         Guards.NotNull(request, nameof(request));
         _validator.ValidateList(request);
 
-        using var activity = StartActivity(ListOperationName);
         var relativePath = _queryStringBuilder.BuildListPath(request);
         using var response = await _transport.SendAsync(
             HttpMethod.Get,
@@ -149,13 +143,6 @@ public sealed class WebhooksClient : IWebhooksClient
             static (iterationRequest, continuationToken) => iterationRequest.ContinuationToken = continuationToken,
             ListAsync,
             cancellationToken);
-    }
-
-    private static Activity? StartActivity(string operationName)
-    {
-        var activity = ActivitySourceProvider.ActivitySource.StartActivity(operationName, ActivityKind.Client);
-        activity?.SetTag("sdk.operation", operationName);
-        return activity;
     }
 
     private static ListWebhooksRequest CloneListRequest(ListWebhooksRequest request)

--- a/src/PublishingPlatform.SDK/Extensions/ServiceCollectionExtensions.cs
+++ b/src/PublishingPlatform.SDK/Extensions/ServiceCollectionExtensions.cs
@@ -1,8 +1,10 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using PublishingPlatform.SDK.Exceptions;
 using PublishingPlatform.SDK.Abstractions;
 using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Errors;
 using PublishingPlatform.SDK.Infrastructure.Http.Handlers;
 using PublishingPlatform.SDK.Infrastructure.Transport;
@@ -76,6 +78,11 @@ public static class ServiceCollectionExtensions
             return options.ErrorMapper ?? new DefaultPublishingPlatformErrorMapper();
         });
         services.AddSingleton<ICorrelationIdProvider, GuidCorrelationIdProvider>();
+        services.AddSingleton<IDiagnosticsOptionsResolver>(sp =>
+        {
+            var options = sp.GetRequiredService<IOptions<PublishingPlatformClientOptions>>().Value;
+            return new DefaultDiagnosticsOptionsResolver(options);
+        });
         services.AddSingleton<HttpPipelinePolicy>();
         services.AddSingleton<ISharedHttpTransport>(sp =>
         {
@@ -83,11 +90,15 @@ public static class ServiceCollectionExtensions
             var pipeline = sp.GetRequiredService<IPublishingPlatformResiliencePipeline>();
             var correlationProvider = sp.GetRequiredService<ICorrelationIdProvider>();
             var errorMapper = sp.GetRequiredService<IPublishingPlatformErrorMapper>();
+            var diagnosticsResolver = sp.GetRequiredService<IDiagnosticsOptionsResolver>();
+            var logger = sp.GetService<ILogger<SharedHttpTransport>>();
             return SharedHttpTransportBuilder.Create()
                 .WithHttpClient(httpClient)
                 .WithResiliencePipeline(pipeline)
                 .WithCorrelationProvider(correlationProvider)
                 .WithErrorMapper(errorMapper)
+                .WithDiagnosticsOptionsResolver(diagnosticsResolver)
+                .WithLogger(logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<SharedHttpTransport>.Instance)
                 .Build();
         });
 
@@ -104,14 +115,25 @@ public static class ServiceCollectionExtensions
 
     private static bool ValidateOptions(PublishingPlatformClientOptions options)
     {
-        if (!Uri.TryCreate(options.BaseUrl, UriKind.Absolute, out _))
+        if (!Uri.TryCreate(options.BaseUrl, UriKind.Absolute, out var baseUri))
         {
             throw new PublishingPlatformConfigurationException("BaseUrl must be a valid absolute URL.");
+        }
+
+        if (baseUri.Scheme != Uri.UriSchemeHttps)
+        {
+            throw new PublishingPlatformConfigurationException("BaseUrl must use HTTPS.");
         }
 
         if (options.Timeout <= TimeSpan.Zero)
         {
             throw new PublishingPlatformConfigurationException("Timeout must be greater than zero.");
+        }
+
+        if (options.Diagnostics is not null
+            && string.IsNullOrWhiteSpace(options.Diagnostics.CorrelationHeaderName))
+        {
+            throw new PublishingPlatformConfigurationException("Diagnostics correlation header name must not be empty.");
         }
 
         return true;

--- a/src/PublishingPlatform.SDK/Infrastructure/Diagnostics/ActivitySourceProvider.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Diagnostics/ActivitySourceProvider.cs
@@ -2,7 +2,13 @@
 
 namespace PublishingPlatform.SDK.Infrastructure.Diagnostics;
 
+/// <summary>
+/// Provides the SDK ActivitySource used by OpenTelemetry-compatible tracing.
+/// </summary>
 public static class ActivitySourceProvider
 {
+    /// <summary>
+    /// Gets the SDK ActivitySource.
+    /// </summary>
     public static ActivitySource ActivitySource { get; } = new("PublishingPlatform.SDK");
 }

--- a/src/PublishingPlatform.SDK/Infrastructure/Diagnostics/DefaultDiagnosticsOptionsResolver.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Diagnostics/DefaultDiagnosticsOptionsResolver.cs
@@ -1,0 +1,57 @@
+using PublishingPlatform.SDK.Options;
+
+namespace PublishingPlatform.SDK.Infrastructure.Diagnostics;
+
+/// <summary>
+/// Resolves module diagnostics options by applying explicit module overrides to global defaults.
+/// </summary>
+internal sealed class DefaultDiagnosticsOptionsResolver : IDiagnosticsOptionsResolver
+{
+    private readonly PublishingPlatformClientOptions _clientOptions;
+
+    public DefaultDiagnosticsOptionsResolver(PublishingPlatformClientOptions clientOptions)
+    {
+        _clientOptions = clientOptions;
+    }
+
+    public ResolvedDiagnosticsOptions Resolve(string moduleName)
+    {
+        var global = _clientOptions.Diagnostics ?? new DiagnosticsOptions();
+        var module = GetModuleOptions(moduleName);
+        var headerName = module?.CorrelationHeaderName;
+        if (string.IsNullOrWhiteSpace(headerName))
+        {
+            headerName = global.CorrelationHeaderName;
+        }
+
+        if (string.IsNullOrWhiteSpace(headerName))
+        {
+            headerName = Transport.TransportHeaderNames.CorrelationId;
+        }
+
+        return new ResolvedDiagnosticsOptions(
+            module?.EnableLogging ?? global.EnableLogging,
+            module?.EnableTracing ?? global.EnableTracing,
+            module?.EnableMetrics ?? global.EnableMetrics,
+            module?.LogRequestBody ?? global.LogRequestBody,
+            module?.LogResponseBody ?? global.LogResponseBody,
+            headerName,
+            module?.GenerateCorrelationIds ?? global.GenerateCorrelationIds);
+    }
+
+    private ModuleDiagnosticsOptions? GetModuleOptions(string moduleName)
+    {
+        return moduleName switch
+        {
+            DiagnosticsModuleNames.Books => _clientOptions.BooksDiagnostics,
+            DiagnosticsModuleNames.BookContent => _clientOptions.BookContentDiagnostics,
+            DiagnosticsModuleNames.BookPublishing => _clientOptions.BookPublishingDiagnostics,
+            DiagnosticsModuleNames.BookDistribution => _clientOptions.BookDistributionDiagnostics,
+            DiagnosticsModuleNames.BookAccess => _clientOptions.BookAccessDiagnostics,
+            DiagnosticsModuleNames.BookAnalytics => _clientOptions.BookAnalyticsDiagnostics,
+            DiagnosticsModuleNames.BookAuditLogs => _clientOptions.BookAuditLogsDiagnostics,
+            DiagnosticsModuleNames.Webhooks => _clientOptions.WebhooksDiagnostics,
+            _ => null,
+        };
+    }
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/Diagnostics/DiagnosticsMeterProvider.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Diagnostics/DiagnosticsMeterProvider.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics.Metrics;
+
+namespace PublishingPlatform.SDK.Infrastructure.Diagnostics;
+
+/// <summary>
+/// Provides SDK metrics instruments for OpenTelemetry-compatible collection.
+/// </summary>
+internal static class DiagnosticsMeterProvider
+{
+    internal static readonly Meter Meter = new("PublishingPlatform.SDK");
+    internal static readonly Counter<long> RequestCounter = Meter.CreateCounter<long>("publishing_platform.sdk.requests");
+    internal static readonly Counter<long> FailureCounter = Meter.CreateCounter<long>("publishing_platform.sdk.request.failures");
+    internal static readonly Histogram<double> RequestDuration = Meter.CreateHistogram<double>("publishing_platform.sdk.request.duration", "ms");
+    internal static readonly Counter<long> RetryCounter = Meter.CreateCounter<long>("publishing_platform.sdk.request.retries");
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/Diagnostics/DiagnosticsModuleNames.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Diagnostics/DiagnosticsModuleNames.cs
@@ -1,0 +1,16 @@
+namespace PublishingPlatform.SDK.Infrastructure.Diagnostics;
+
+/// <summary>
+/// Defines stable diagnostics module names used by SDK telemetry.
+/// </summary>
+internal static class DiagnosticsModuleNames
+{
+    internal const string Books = "Books";
+    internal const string BookContent = "BookContent";
+    internal const string BookPublishing = "BookPublishing";
+    internal const string BookDistribution = "BookDistribution";
+    internal const string BookAccess = "BookAccess";
+    internal const string BookAnalytics = "BookAnalytics";
+    internal const string BookAuditLogs = "BookAuditLogs";
+    internal const string Webhooks = "Webhooks";
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/Diagnostics/DiagnosticsOptions.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Diagnostics/DiagnosticsOptions.cs
@@ -1,8 +1,42 @@
-﻿namespace PublishingPlatform.SDK.Infrastructure.Diagnostics;
+namespace PublishingPlatform.SDK.Infrastructure.Diagnostics;
 
+/// <summary>
+/// Configures SDK diagnostics behavior for logging, tracing, metrics, and correlation.
+/// </summary>
 public sealed class DiagnosticsOptions
 {
-    public bool EnableTracing { get; set; } = true;
+    /// <summary>
+    /// Gets or sets a value indicating whether SDK request lifecycle logging is enabled.
+    /// </summary>
+    public bool EnableLogging { get; set; }
 
-    public bool EnableMetrics { get; set; } = true;
+    /// <summary>
+    /// Gets or sets a value indicating whether SDK Activity-based tracing is enabled.
+    /// </summary>
+    public bool EnableTracing { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether SDK metrics are recorded.
+    /// </summary>
+    public bool EnableMetrics { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether request bodies are logged.
+    /// </summary>
+    public bool LogRequestBody { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether response bodies are logged.
+    /// </summary>
+    public bool LogResponseBody { get; set; }
+
+    /// <summary>
+    /// Gets or sets the HTTP header name used to propagate correlation IDs.
+    /// </summary>
+    public string CorrelationHeaderName { get; set; } = "X-Correlation-Id";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the SDK generates correlation IDs for outgoing requests.
+    /// </summary>
+    public bool GenerateCorrelationIds { get; set; } = true;
 }

--- a/src/PublishingPlatform.SDK/Infrastructure/Diagnostics/IDiagnosticsOptionsResolver.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Diagnostics/IDiagnosticsOptionsResolver.cs
@@ -1,0 +1,9 @@
+namespace PublishingPlatform.SDK.Infrastructure.Diagnostics;
+
+/// <summary>
+/// Resolves effective diagnostics options for SDK modules.
+/// </summary>
+internal interface IDiagnosticsOptionsResolver
+{
+    ResolvedDiagnosticsOptions Resolve(string moduleName);
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/Diagnostics/ModuleDiagnosticsOptions.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Diagnostics/ModuleDiagnosticsOptions.cs
@@ -1,0 +1,42 @@
+namespace PublishingPlatform.SDK.Infrastructure.Diagnostics;
+
+/// <summary>
+/// Overrides global diagnostics behavior for one SDK module when a value is explicitly set.
+/// </summary>
+public sealed class ModuleDiagnosticsOptions
+{
+    /// <summary>
+    /// Gets or sets an override for SDK request lifecycle logging.
+    /// </summary>
+    public bool? EnableLogging { get; set; }
+
+    /// <summary>
+    /// Gets or sets an override for SDK Activity-based tracing.
+    /// </summary>
+    public bool? EnableTracing { get; set; }
+
+    /// <summary>
+    /// Gets or sets an override for SDK metrics recording.
+    /// </summary>
+    public bool? EnableMetrics { get; set; }
+
+    /// <summary>
+    /// Gets or sets an override for request body logging.
+    /// </summary>
+    public bool? LogRequestBody { get; set; }
+
+    /// <summary>
+    /// Gets or sets an override for response body logging.
+    /// </summary>
+    public bool? LogResponseBody { get; set; }
+
+    /// <summary>
+    /// Gets or sets an override for the correlation header name.
+    /// </summary>
+    public string? CorrelationHeaderName { get; set; }
+
+    /// <summary>
+    /// Gets or sets an override for SDK-generated correlation IDs.
+    /// </summary>
+    public bool? GenerateCorrelationIds { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/Diagnostics/RequestDiagnosticsContext.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Diagnostics/RequestDiagnosticsContext.cs
@@ -1,0 +1,44 @@
+namespace PublishingPlatform.SDK.Infrastructure.Diagnostics;
+
+/// <summary>
+/// Carries diagnostics metadata for one outbound SDK request.
+/// </summary>
+internal sealed class RequestDiagnosticsContext
+{
+    public RequestDiagnosticsContext(
+        string moduleName,
+        string operationName,
+        HttpMethod method,
+        string relativePath,
+        string? correlationId,
+        ResolvedDiagnosticsOptions options)
+    {
+        ModuleName = moduleName;
+        OperationName = operationName;
+        Method = method;
+        RelativePath = relativePath;
+        CorrelationId = correlationId;
+        Options = options;
+    }
+
+    public string ModuleName { get; }
+
+    public string OperationName { get; }
+
+    public HttpMethod Method { get; }
+
+    public string RelativePath { get; }
+
+    public string? CorrelationId { get; }
+
+    public ResolvedDiagnosticsOptions Options { get; }
+
+    public string SanitizedPath
+    {
+        get
+        {
+            var queryIndex = RelativePath.IndexOf('?', StringComparison.Ordinal);
+            return queryIndex < 0 ? RelativePath : RelativePath[..queryIndex];
+        }
+    }
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/Diagnostics/ResolvedDiagnosticsOptions.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Diagnostics/ResolvedDiagnosticsOptions.cs
@@ -1,0 +1,39 @@
+namespace PublishingPlatform.SDK.Infrastructure.Diagnostics;
+
+/// <summary>
+/// Represents the effective diagnostics behavior for a single SDK module request.
+/// </summary>
+internal sealed class ResolvedDiagnosticsOptions
+{
+    public ResolvedDiagnosticsOptions(
+        bool enableLogging,
+        bool enableTracing,
+        bool enableMetrics,
+        bool logRequestBody,
+        bool logResponseBody,
+        string correlationHeaderName,
+        bool generateCorrelationIds)
+    {
+        EnableLogging = enableLogging;
+        EnableTracing = enableTracing;
+        EnableMetrics = enableMetrics;
+        LogRequestBody = logRequestBody;
+        LogResponseBody = logResponseBody;
+        CorrelationHeaderName = correlationHeaderName;
+        GenerateCorrelationIds = generateCorrelationIds;
+    }
+
+    public bool EnableLogging { get; }
+
+    public bool EnableTracing { get; }
+
+    public bool EnableMetrics { get; }
+
+    public bool LogRequestBody { get; }
+
+    public bool LogResponseBody { get; }
+
+    public string CorrelationHeaderName { get; }
+
+    public bool GenerateCorrelationIds { get; }
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/Http/Handlers/DiagnosticsHandler.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Http/Handlers/DiagnosticsHandler.cs
@@ -1,12 +1,41 @@
-﻿namespace PublishingPlatform.SDK.Infrastructure.Http.Handlers;
+using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 
+namespace PublishingPlatform.SDK.Infrastructure.Http.Handlers;
+
+/// <summary>
+/// Provides an opt-in diagnostics delegating handler for HTTP pipelines that use handlers directly.
+/// </summary>
 public sealed class DiagnosticsHandler : DelegatingHandler
 {
+    private readonly DiagnosticsOptions _options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DiagnosticsHandler"/> class with safe diagnostics defaults.
+    /// </summary>
+    public DiagnosticsHandler()
+        : this(new DiagnosticsOptions())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DiagnosticsHandler"/> class.
+    /// </summary>
+    /// <param name="options">The diagnostics options that control handler behavior.</param>
+    public DiagnosticsHandler(DiagnosticsOptions options)
+    {
+        _options = options;
+    }
+
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var activity = Diagnostics.ActivitySourceProvider.ActivitySource.StartActivity("PublishingPlatform.HttpRequest");
+        if (!_options.EnableTracing)
+        {
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        using var activity = ActivitySourceProvider.ActivitySource.StartActivity("PublishingPlatform.HttpRequest");
         activity?.SetTag("http.method", request.Method.Method);
-        activity?.SetTag("http.url", request.RequestUri?.ToString());
+        activity?.SetTag("url.path", request.RequestUri?.AbsolutePath);
 
         var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
         activity?.SetTag("http.status_code", (int)response.StatusCode);

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/Errors/DefaultTransportErrorContextFactory.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/Errors/DefaultTransportErrorContextFactory.cs
@@ -9,7 +9,7 @@ internal sealed class DefaultTransportErrorContextFactory : ITransportErrorConte
         string relativePath,
         int statusCode,
         string message,
-        string correlationId,
+        string? correlationId,
         string? operationName)
     {
         return new PublishingPlatformErrorContext

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/Errors/ITransportErrorContextFactory.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/Errors/ITransportErrorContextFactory.cs
@@ -9,6 +9,6 @@ internal interface ITransportErrorContextFactory
         string relativePath,
         int statusCode,
         string message,
-        string correlationId,
+        string? correlationId,
         string? operationName);
 }

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/ISharedHttpTransport.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/ISharedHttpTransport.cs
@@ -8,5 +8,6 @@ internal interface ISharedHttpTransport
         HttpContent? content,
         IReadOnlyDictionary<string, string>? headers = null,
         string? operationName = null,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default,
+        string? moduleName = null);
 }

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/Requests/DefaultTransportRequestFactory.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/Requests/DefaultTransportRequestFactory.cs
@@ -12,22 +12,36 @@ internal sealed class DefaultTransportRequestFactory : ITransportRequestFactory
         string correlationId,
         IReadOnlyDictionary<string, string>? headers = null)
     {
+        return Create(method, relativePath, content, TransportHeaderNames.CorrelationId, correlationId, headers);
+    }
+
+    public HttpRequestMessage Create(
+        HttpMethod method,
+        string relativePath,
+        HttpContent? content,
+        string correlationHeaderName,
+        string? correlationId,
+        IReadOnlyDictionary<string, string>? headers = null)
+    {
         var request = new HttpRequestMessage(method, relativePath)
         {
             Content = content,
         };
 
-        if (!request.Headers.Contains(TransportHeaderNames.CorrelationId))
-        {
-            request.Headers.Add(TransportHeaderNames.CorrelationId, correlationId);
-        }
-
         if (headers is not null)
         {
-            foreach (var header in headers.Where(x => !request.Headers.TryAddWithoutValidation(x.Key, x.Value)))
+            foreach (var header in headers)
             {
-                request.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                if (!request.Headers.TryAddWithoutValidation(header.Key, header.Value))
+                {
+                    request.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
             }
+        }
+
+        if (!string.IsNullOrWhiteSpace(correlationId) && !request.Headers.Contains(correlationHeaderName))
+        {
+            request.Headers.Add(correlationHeaderName, correlationId);
         }
 
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/Requests/ITransportRequestFactory.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/Requests/ITransportRequestFactory.cs
@@ -6,6 +6,7 @@ internal interface ITransportRequestFactory
         HttpMethod method,
         string relativePath,
         HttpContent? content,
-        string correlationId,
+        string correlationHeaderName,
+        string? correlationId,
         IReadOnlyDictionary<string, string>? headers = null);
 }

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/SdkHttpClientResolver.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/SdkHttpClientResolver.cs
@@ -21,6 +21,11 @@ internal static class SdkHttpClientResolver
             throw new PublishingPlatformConfigurationException("BaseUrl must be a valid absolute URL.");
         }
 
+        if (baseAddress.Scheme != Uri.UriSchemeHttps)
+        {
+            throw new PublishingPlatformConfigurationException("BaseUrl must use HTTPS.");
+        }
+
         var services = new ServiceCollection();
         services.AddHttpClient(ClientName, client =>
         {

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransport.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransport.cs
@@ -1,9 +1,19 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Infrastructure.Diagnostics;
+using PublishingPlatform.SDK.Infrastructure.Errors;
 using PublishingPlatform.SDK.Infrastructure.Transport.Errors;
 using PublishingPlatform.SDK.Infrastructure.Transport.Requests;
+using PublishingPlatform.SDK.Options;
 
 namespace PublishingPlatform.SDK.Infrastructure.Transport;
 
+/// <summary>
+/// Sends SDK HTTP requests through resilience, diagnostics, correlation, and error-mapping infrastructure.
+/// </summary>
 internal sealed class SharedHttpTransport : ISharedHttpTransport
 {
     internal const string CorrelationHeaderName = TransportHeaderNames.CorrelationId;
@@ -15,13 +25,22 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
     private readonly ITransportRequestFactory _requestFactory;
     private readonly ITransportResponseErrorReader _responseErrorReader;
     private readonly ITransportErrorContextFactory _errorContextFactory;
+    private readonly IDiagnosticsOptionsResolver _diagnosticsOptionsResolver;
+    private readonly ILogger<SharedHttpTransport> _logger;
 
     public SharedHttpTransport(
         HttpClient httpClient,
         IPublishingPlatformResiliencePipeline resiliencePipeline,
         ICorrelationIdProvider correlationIdProvider,
         IPublishingPlatformErrorMapper errorMapper)
-        : this(httpClient, resiliencePipeline, correlationIdProvider, errorMapper, TransportDependencies.CreateDefault())
+        : this(
+            httpClient,
+            resiliencePipeline,
+            correlationIdProvider,
+            errorMapper,
+            TransportDependencies.CreateDefault(),
+            new DefaultDiagnosticsOptionsResolver(new PublishingPlatformClientOptions()),
+            NullLogger<SharedHttpTransport>.Instance)
     {
     }
 
@@ -30,7 +49,9 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
         IPublishingPlatformResiliencePipeline resiliencePipeline,
         ICorrelationIdProvider correlationIdProvider,
         IPublishingPlatformErrorMapper errorMapper,
-        TransportDependencies dependencies)
+        TransportDependencies dependencies,
+        IDiagnosticsOptionsResolver diagnosticsOptionsResolver,
+        ILogger<SharedHttpTransport> logger)
         : this(
             httpClient,
             resiliencePipeline,
@@ -38,7 +59,9 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
             errorMapper,
             dependencies.RequestFactory,
             dependencies.ResponseErrorReader,
-            dependencies.ErrorContextFactory)
+            dependencies.ErrorContextFactory,
+            diagnosticsOptionsResolver,
+            logger)
     {
     }
 
@@ -50,6 +73,29 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
         ITransportRequestFactory requestFactory,
         ITransportResponseErrorReader responseErrorReader,
         ITransportErrorContextFactory errorContextFactory)
+        : this(
+            httpClient,
+            resiliencePipeline,
+            correlationIdProvider,
+            errorMapper,
+            requestFactory,
+            responseErrorReader,
+            errorContextFactory,
+            new DefaultDiagnosticsOptionsResolver(new PublishingPlatformClientOptions()),
+            NullLogger<SharedHttpTransport>.Instance)
+    {
+    }
+
+    internal SharedHttpTransport(
+        HttpClient httpClient,
+        IPublishingPlatformResiliencePipeline resiliencePipeline,
+        ICorrelationIdProvider correlationIdProvider,
+        IPublishingPlatformErrorMapper errorMapper,
+        ITransportRequestFactory requestFactory,
+        ITransportResponseErrorReader responseErrorReader,
+        ITransportErrorContextFactory errorContextFactory,
+        IDiagnosticsOptionsResolver diagnosticsOptionsResolver,
+        ILogger<SharedHttpTransport> logger)
     {
         _httpClient = httpClient;
         _resiliencePipeline = resiliencePipeline;
@@ -58,6 +104,8 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
         _requestFactory = requestFactory;
         _responseErrorReader = responseErrorReader;
         _errorContextFactory = errorContextFactory;
+        _diagnosticsOptionsResolver = diagnosticsOptionsResolver;
+        _logger = logger;
     }
 
     public async Task<HttpResponseMessage> SendAsync(
@@ -66,35 +114,246 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
         HttpContent? content,
         IReadOnlyDictionary<string, string>? headers = null,
         string? operationName = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        string? moduleName = null)
     {
-        var correlationId = _correlationIdProvider.Create();
-        var response = await _resiliencePipeline.ExecuteAsync(
-            new PublishingPlatformResilienceContext
-            {
-                Method = method,
-            },
-            async ct =>
-            {
-                using var request = _requestFactory.Create(method, relativePath, content, correlationId, headers);
-                return await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
-            },
-            cancellationToken).ConfigureAwait(false);
-
-        if (response.IsSuccessStatusCode)
-        {
-            return response;
-        }
-
-        var message = await _responseErrorReader.ReadAsync(response, cancellationToken).ConfigureAwait(false);
-        var context = _errorContextFactory.Create(
+        var effectiveOperationName = string.IsNullOrWhiteSpace(operationName)
+            ? "SDK.HttpRequest"
+            : operationName;
+        var effectiveModuleName = string.IsNullOrWhiteSpace(moduleName)
+            ? ResolveModuleName(effectiveOperationName)
+            : moduleName;
+        var options = _diagnosticsOptionsResolver.Resolve(effectiveModuleName);
+        var correlationId = ResolveCorrelationId(headers, options);
+        var diagnosticsContext = new RequestDiagnosticsContext(
+            effectiveModuleName,
+            effectiveOperationName,
             method,
             relativePath,
-            (int)response.StatusCode,
-            message,
             correlationId,
-            operationName);
+            options);
 
-        throw _errorMapper.Map(context);
+        using var activity = StartActivity(diagnosticsContext);
+        LogRequestStarting(diagnosticsContext);
+
+        var started = Stopwatch.GetTimestamp();
+        var attempts = 0;
+
+        try
+        {
+            var response = await _resiliencePipeline.ExecuteAsync(
+                new PublishingPlatformResilienceContext
+                {
+                    Method = method,
+                },
+                async ct =>
+                {
+                    attempts++;
+                    using var request = _requestFactory.Create(
+                        method,
+                        relativePath,
+                        content,
+                        options.CorrelationHeaderName,
+                        correlationId,
+                        headers);
+                    return await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+                },
+                cancellationToken).ConfigureAwait(false);
+
+            var elapsed = GetElapsedMilliseconds(started);
+            activity?.SetTag("http.status_code", (int)response.StatusCode);
+
+            if (response.IsSuccessStatusCode)
+            {
+                LogRequestCompleted(diagnosticsContext, response, elapsed);
+                RecordMetrics(diagnosticsContext, response, elapsed, attempts);
+                return response;
+            }
+
+            LogRequestCompleted(diagnosticsContext, response, elapsed);
+            RecordMetrics(diagnosticsContext, response, elapsed, attempts);
+
+            var message = await _responseErrorReader.ReadAsync(response, cancellationToken).ConfigureAwait(false);
+            var context = _errorContextFactory.Create(
+                method,
+                relativePath,
+                (int)response.StatusCode,
+                message,
+                correlationId,
+                operationName);
+
+            throw _errorMapper.Map(context);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            var elapsed = GetElapsedMilliseconds(started);
+            activity?.SetTag("error.type", ex.GetType().Name);
+            LogRequestFailed(diagnosticsContext, ex, elapsed);
+            RecordFailureMetrics(diagnosticsContext, elapsed, attempts);
+            throw;
+        }
+    }
+
+    private string? ResolveCorrelationId(
+        IReadOnlyDictionary<string, string>? headers,
+        ResolvedDiagnosticsOptions options)
+    {
+        if (headers is not null)
+        {
+            foreach (var header in headers)
+            {
+                if (string.Equals(header.Key, options.CorrelationHeaderName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return header.Value;
+                }
+            }
+        }
+
+        return options.GenerateCorrelationIds ? _correlationIdProvider.Create() : null;
+    }
+
+    private static string ResolveModuleName(string operationName)
+    {
+        var separatorIndex = operationName.IndexOf('.', StringComparison.Ordinal);
+        return separatorIndex <= 0 ? "SDK" : operationName[..separatorIndex];
+    }
+
+    private static Activity? StartActivity(RequestDiagnosticsContext context)
+    {
+        if (!context.Options.EnableTracing)
+        {
+            return null;
+        }
+
+        var activity = ActivitySourceProvider.ActivitySource.StartActivity(context.OperationName, ActivityKind.Client);
+        activity?.SetTag("sdk.module", context.ModuleName);
+        activity?.SetTag("sdk.operation", context.OperationName);
+        activity?.SetTag("http.method", context.Method.Method);
+        activity?.SetTag("url.path", context.SanitizedPath);
+        activity?.SetTag("correlation.id", context.CorrelationId);
+        return activity;
+    }
+
+    private static double GetElapsedMilliseconds(long started)
+    {
+        return Stopwatch.GetElapsedTime(started).TotalMilliseconds;
+    }
+
+    private void LogRequestStarting(RequestDiagnosticsContext context)
+    {
+        if (!context.Options.EnableLogging)
+        {
+            return;
+        }
+
+        _logger.LogInformation(
+            "SDK request started: {Module} {Operation} {Method} {Path} {CorrelationId}",
+            context.ModuleName,
+            context.OperationName,
+            context.Method.Method,
+            context.SanitizedPath,
+            context.CorrelationId);
+    }
+
+    private void LogRequestCompleted(
+        RequestDiagnosticsContext context,
+        HttpResponseMessage response,
+        double elapsedMilliseconds)
+    {
+        if (!context.Options.EnableLogging)
+        {
+            return;
+        }
+
+        _logger.LogInformation(
+            "SDK request completed: {Module} {Operation} {Method} {Path} {StatusCode} {ElapsedMilliseconds} {CorrelationId}",
+            context.ModuleName,
+            context.OperationName,
+            context.Method.Method,
+            context.SanitizedPath,
+            (int)response.StatusCode,
+            elapsedMilliseconds,
+            context.CorrelationId);
+    }
+
+    private void LogRequestFailed(
+        RequestDiagnosticsContext context,
+        Exception exception,
+        double elapsedMilliseconds)
+    {
+        if (!context.Options.EnableLogging)
+        {
+            return;
+        }
+
+        _logger.LogError(
+            exception,
+            "SDK request failed: {Module} {Operation} {Method} {Path} {ElapsedMilliseconds} {CorrelationId}",
+            context.ModuleName,
+            context.OperationName,
+            context.Method.Method,
+            context.SanitizedPath,
+            elapsedMilliseconds,
+            context.CorrelationId);
+    }
+
+    private static void RecordMetrics(
+        RequestDiagnosticsContext context,
+        HttpResponseMessage response,
+        double elapsedMilliseconds,
+        int attempts)
+    {
+        if (!context.Options.EnableMetrics)
+        {
+            return;
+        }
+
+        var tags = CreateMetricTags(context);
+        tags.Add("http.status_code", (int)response.StatusCode);
+        DiagnosticsMeterProvider.RequestCounter.Add(1, tags);
+        DiagnosticsMeterProvider.RequestDuration.Record(elapsedMilliseconds, tags);
+        if (!response.IsSuccessStatusCode)
+        {
+            DiagnosticsMeterProvider.FailureCounter.Add(1, tags);
+        }
+
+        RecordRetryCount(context, attempts);
+    }
+
+    private static void RecordFailureMetrics(
+        RequestDiagnosticsContext context,
+        double elapsedMilliseconds,
+        int attempts)
+    {
+        if (!context.Options.EnableMetrics)
+        {
+            return;
+        }
+
+        var tags = CreateMetricTags(context);
+        DiagnosticsMeterProvider.FailureCounter.Add(1, tags);
+        DiagnosticsMeterProvider.RequestDuration.Record(elapsedMilliseconds, tags);
+        RecordRetryCount(context, attempts);
+    }
+
+    private static void RecordRetryCount(RequestDiagnosticsContext context, int attempts)
+    {
+        if (!context.Options.EnableMetrics || attempts <= 1)
+        {
+            return;
+        }
+
+        DiagnosticsMeterProvider.RetryCounter.Add(attempts - 1, CreateMetricTags(context));
+    }
+
+    private static TagList CreateMetricTags(RequestDiagnosticsContext context)
+    {
+        var tags = new TagList
+        {
+            { "sdk.module", context.ModuleName },
+            { "sdk.operation", context.OperationName },
+            { "http.method", context.Method.Method },
+        };
+        return tags;
     }
 }

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransportBuilder.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransportBuilder.cs
@@ -1,6 +1,10 @@
 using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Transport.Errors;
 using PublishingPlatform.SDK.Infrastructure.Transport.Requests;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using PublishingPlatform.SDK.Options;
 
 namespace PublishingPlatform.SDK.Infrastructure.Transport;
 
@@ -13,6 +17,9 @@ internal sealed class SharedHttpTransportBuilder
     private ITransportRequestFactory _requestFactory = new DefaultTransportRequestFactory();
     private ITransportResponseErrorReader _responseErrorReader = new DefaultTransportResponseErrorReader();
     private ITransportErrorContextFactory _errorContextFactory = new DefaultTransportErrorContextFactory();
+    private IDiagnosticsOptionsResolver _diagnosticsOptionsResolver =
+        new DefaultDiagnosticsOptionsResolver(new PublishingPlatformClientOptions());
+    private ILogger<SharedHttpTransport> _logger = NullLogger<SharedHttpTransport>.Instance;
 
     private SharedHttpTransportBuilder()
     {
@@ -65,6 +72,18 @@ internal sealed class SharedHttpTransportBuilder
         return this;
     }
 
+    public SharedHttpTransportBuilder WithDiagnosticsOptionsResolver(IDiagnosticsOptionsResolver diagnosticsOptionsResolver)
+    {
+        _diagnosticsOptionsResolver = diagnosticsOptionsResolver;
+        return this;
+    }
+
+    public SharedHttpTransportBuilder WithLogger(ILogger<SharedHttpTransport> logger)
+    {
+        _logger = logger;
+        return this;
+    }
+
     public SharedHttpTransport Build()
     {
         return new SharedHttpTransport(
@@ -74,6 +93,8 @@ internal sealed class SharedHttpTransportBuilder
             _errorMapper ?? throw new InvalidOperationException("Error mapper is required."),
             _requestFactory,
             _responseErrorReader,
-            _errorContextFactory);
+            _errorContextFactory,
+            _diagnosticsOptionsResolver,
+            _logger);
     }
 }

--- a/src/PublishingPlatform.SDK/Options/PublishingPlatformClientOptions.cs
+++ b/src/PublishingPlatform.SDK/Options/PublishingPlatformClientOptions.cs
@@ -1,16 +1,80 @@
 using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 
 namespace PublishingPlatform.SDK.Options;
 
+/// <summary>
+/// Configures the Publishing Platform SDK client.
+/// </summary>
 public sealed class PublishingPlatformClientOptions
 {
+    /// <summary>
+    /// Gets or sets the Publishing Platform API base URL.
+    /// </summary>
     public string BaseUrl { get; set; } = "https://api.publishing-platform.local";
 
+    /// <summary>
+    /// Gets or sets the API key used by the SDK.
+    /// </summary>
     public string ApiKey { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Gets or sets the HTTP timeout used by the SDK client.
+    /// </summary>
     public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
 
+    /// <summary>
+    /// Gets or sets resilience configuration for retry, timeout, and circuit breaker behavior.
+    /// </summary>
     public PublishingPlatformResilienceOptions? Resilience { get; set; }
 
+    /// <summary>
+    /// Gets or sets a custom error mapper for SDK HTTP failures.
+    /// </summary>
     public IPublishingPlatformErrorMapper? ErrorMapper { get; set; }
+
+    /// <summary>
+    /// Gets or sets global diagnostics configuration inherited by all SDK modules.
+    /// </summary>
+    public DiagnosticsOptions? Diagnostics { get; set; }
+
+    /// <summary>
+    /// Gets or sets diagnostics overrides for the books module.
+    /// </summary>
+    public ModuleDiagnosticsOptions? BooksDiagnostics { get; set; }
+
+    /// <summary>
+    /// Gets or sets diagnostics overrides for the book content module.
+    /// </summary>
+    public ModuleDiagnosticsOptions? BookContentDiagnostics { get; set; }
+
+    /// <summary>
+    /// Gets or sets diagnostics overrides for the book publishing module.
+    /// </summary>
+    public ModuleDiagnosticsOptions? BookPublishingDiagnostics { get; set; }
+
+    /// <summary>
+    /// Gets or sets diagnostics overrides for the book distribution module.
+    /// </summary>
+    public ModuleDiagnosticsOptions? BookDistributionDiagnostics { get; set; }
+
+    /// <summary>
+    /// Gets or sets diagnostics overrides for the book access module.
+    /// </summary>
+    public ModuleDiagnosticsOptions? BookAccessDiagnostics { get; set; }
+
+    /// <summary>
+    /// Gets or sets diagnostics overrides for the book analytics module.
+    /// </summary>
+    public ModuleDiagnosticsOptions? BookAnalyticsDiagnostics { get; set; }
+
+    /// <summary>
+    /// Gets or sets diagnostics overrides for the book audit logs module.
+    /// </summary>
+    public ModuleDiagnosticsOptions? BookAuditLogsDiagnostics { get; set; }
+
+    /// <summary>
+    /// Gets or sets diagnostics overrides for the webhooks module.
+    /// </summary>
+    public ModuleDiagnosticsOptions? WebhooksDiagnostics { get; set; }
 }

--- a/src/PublishingPlatform.SDK/PublishingPlatform.SDK.csproj
+++ b/src/PublishingPlatform.SDK/PublishingPlatform.SDK.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Polly.Core" />
   </ItemGroup>
 </Project>

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/InfrastructureContractsTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/InfrastructureContractsTests.cs
@@ -179,9 +179,61 @@ public sealed class InfrastructureContractsTests
         var diagnostics = new DiagnosticsOptions();
         var pagination = new PaginationRequest();
 
-        diagnostics.EnableTracing.Should().BeTrue();
-        diagnostics.EnableMetrics.Should().BeTrue();
+        diagnostics.EnableLogging.Should().BeFalse();
+        diagnostics.EnableTracing.Should().BeFalse();
+        diagnostics.EnableMetrics.Should().BeFalse();
+        diagnostics.LogRequestBody.Should().BeFalse();
+        diagnostics.LogResponseBody.Should().BeFalse();
+        diagnostics.CorrelationHeaderName.Should().Be("X-Correlation-Id");
+        diagnostics.GenerateCorrelationIds.Should().BeTrue();
         pagination.PageSize.Should().Be(50);
         pagination.ContinuationToken.Should().BeNull();
+    }
+
+    [Fact]
+    public void DiagnosticsResolver_InheritsGlobalOptions_WhenModuleOverrideUnset()
+    {
+        var resolver = new DefaultDiagnosticsOptionsResolver(new PublishingPlatform.SDK.Options.PublishingPlatformClientOptions
+        {
+            Diagnostics = new DiagnosticsOptions
+            {
+                EnableLogging = true,
+                EnableTracing = true,
+                EnableMetrics = true,
+                CorrelationHeaderName = "X-Trace-Id",
+                GenerateCorrelationIds = false,
+            },
+        });
+
+        var resolved = resolver.Resolve("Books");
+
+        resolved.EnableLogging.Should().BeTrue();
+        resolved.EnableTracing.Should().BeTrue();
+        resolved.EnableMetrics.Should().BeTrue();
+        resolved.CorrelationHeaderName.Should().Be("X-Trace-Id");
+        resolved.GenerateCorrelationIds.Should().BeFalse();
+    }
+
+    [Fact]
+    public void DiagnosticsResolver_AppliesExplicitModuleOverrides()
+    {
+        var resolver = new DefaultDiagnosticsOptionsResolver(new PublishingPlatform.SDK.Options.PublishingPlatformClientOptions
+        {
+            Diagnostics = new DiagnosticsOptions
+            {
+                EnableLogging = true,
+                EnableTracing = false,
+            },
+            BookContentDiagnostics = new ModuleDiagnosticsOptions
+            {
+                EnableLogging = false,
+                EnableTracing = true,
+            },
+        });
+
+        var resolved = resolver.Resolve("BookContent");
+
+        resolved.EnableLogging.Should().BeFalse();
+        resolved.EnableTracing.Should().BeTrue();
     }
 }

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/ModuleContractConformanceTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/ModuleContractConformanceTests.cs
@@ -1,8 +1,6 @@
-using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Json;
 using System.Reflection;
-using System.Collections.Concurrent;
 using System.Text;
 using PublishingPlatform.SDK.Abstractions;
 using PublishingPlatform.SDK.Clients;
@@ -118,20 +116,15 @@ public sealed class ModuleContractConformanceTests
     }
 
     [Fact]
-    public async Task ModuleMethods_EmitExpectedDiagnosticActivityAndOperationNames()
+    public async Task ModuleMethods_PassExpectedDiagnosticOperationNames()
     {
         var cases = BuildDiagnosticInvocationCases();
 
         foreach (var diagnosticCase in cases)
         {
             var transport = CreateSuccessfulTransport();
-            var startedActivities = new ConcurrentQueue<Activity>();
-            var stoppedActivities = new ConcurrentQueue<Activity>();
-            using var listener = CreatePublishingSdkActivityListener(startedActivities, stoppedActivities);
 
             await diagnosticCase.InvokeAsync(transport);
-            var startedSnapshot = startedActivities.ToArray();
-            var stoppedSnapshot = stoppedActivities.ToArray();
 
             await transport.Received(1).SendAsync(
                 Arg.Any<HttpMethod>(),
@@ -140,17 +133,6 @@ public sealed class ModuleContractConformanceTests
                 Arg.Any<IReadOnlyDictionary<string, string>?>(),
                 diagnosticCase.ExpectedOperationName,
                 Arg.Any<CancellationToken>());
-
-            startedSnapshot.Should().Contain(
-                activity => activity.OperationName == diagnosticCase.ExpectedOperationName,
-                $"{diagnosticCase.ScenarioName} should start the expected SDK activity");
-            stoppedSnapshot.Should().Contain(
-                activity => activity.OperationName == diagnosticCase.ExpectedOperationName,
-                $"{diagnosticCase.ScenarioName} should stop the expected SDK activity");
-            var startedActivity = startedSnapshot.First(activity => activity.OperationName == diagnosticCase.ExpectedOperationName);
-            startedActivity.Tags.Should().Contain(
-                tag => tag.Key == "sdk.operation" && tag.Value as string == diagnosticCase.ExpectedOperationName,
-                $"{diagnosticCase.ScenarioName} should stamp the sdk.operation diagnostic tag");
         }
     }
 
@@ -375,23 +357,6 @@ public sealed class ModuleContractConformanceTests
         {
             Content = JsonContent.Create(payload),
         };
-    }
-
-    private static ActivityListener CreatePublishingSdkActivityListener(
-        ConcurrentQueue<Activity> startedActivities,
-        ConcurrentQueue<Activity> stoppedActivities)
-    {
-        var listener = new ActivityListener
-        {
-            ShouldListenTo = activitySource => activitySource.Name == "PublishingPlatform.SDK",
-            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
-            SampleUsingParentId = static (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded,
-            ActivityStarted = activity => startedActivities.Enqueue(activity),
-            ActivityStopped = activity => stoppedActivities.Enqueue(activity),
-        };
-
-        ActivitySource.AddActivityListener(listener);
-        return listener;
     }
 
     private static DiagnosticInvocationCase[] BuildDiagnosticInvocationCases()

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/OpenApiSpecificationContractsTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/OpenApiSpecificationContractsTests.cs
@@ -10,7 +10,7 @@ namespace PublishingPlatform.SDK.Tests.Infrastructure;
 public sealed class OpenApiSpecificationContractsTests
 {
     private const string SpecRelativePath = @"docs\openapi-google-books-derived-sdk-contract.yaml";
-    private const string ExpectedSha256 = "7edd6c1fdfc6590805f1bdd34f2265db992d78e7296d312596b783caf9ae6520";
+    private const string ExpectedSha256 = "36ebfa91e7e053bb3f22be4dea7414c3dd031c1f8f4d38560429be4529865d4e";
 
     private static readonly string[] ExpectedOperations =
     {

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/ResilienceAndTransportTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/ResilienceAndTransportTests.cs
@@ -1,13 +1,20 @@
 using Bogus;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using PublishingPlatform.SDK.Abstractions;
 using PublishingPlatform.SDK.Exceptions;
 using PublishingPlatform.SDK.Extensions;
+using PublishingPlatform.SDK.Infrastructure.Diagnostics;
 using PublishingPlatform.SDK.Infrastructure.Errors;
 using PublishingPlatform.SDK.Infrastructure.Transport;
+using PublishingPlatform.SDK.Infrastructure.Transport.Errors;
+using PublishingPlatform.SDK.Infrastructure.Transport.Requests;
 using PublishingPlatform.SDK.Internal.Resilience;
 using PublishingPlatform.SDK.Options;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Net;
 using System.Net.Http.Json;
 
@@ -45,6 +52,289 @@ public sealed class ResilienceAndTransportTests
         values.Should().ContainSingle().Which.Should().Be(correlationId);
         handler.LastRequest.RequestUri!.ToString().Should().Be("https://api.example.test/books");
         correlationProvider.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SendAsync_PreservesProvidedCorrelationHeader_AndDoesNotGenerateNewId()
+    {
+        const string expectedCorrelationId = "caller-correlation";
+        var correlationProvider = new FixedCorrelationIdProvider("generated-correlation");
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.test") };
+        var transport = CreateDiagnosticsTransport(
+            httpClient,
+            correlationProvider,
+            new PublishingPlatformClientOptions
+            {
+                Diagnostics = new DiagnosticsOptions(),
+            });
+        var headers = new Dictionary<string, string>
+        {
+            [SharedHttpTransport.CorrelationHeaderName] = expectedCorrelationId,
+        };
+
+        await transport.SendAsync(HttpMethod.Get, "/books", null, headers, "Books.GetById", CancellationToken.None, "Books");
+
+        handler.LastRequest!.Headers.TryGetValues(SharedHttpTransport.CorrelationHeaderName, out var values).Should().BeTrue();
+        values.Should().ContainSingle().Which.Should().Be(expectedCorrelationId);
+        correlationProvider.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SendAsync_UsesCustomCorrelationHeaderName()
+    {
+        const string headerName = "X-Trace-Id";
+        const string correlationId = "trace-123";
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.test") };
+        var transport = CreateDiagnosticsTransport(
+            httpClient,
+            new FixedCorrelationIdProvider(correlationId),
+            new PublishingPlatformClientOptions
+            {
+                Diagnostics = new DiagnosticsOptions
+                {
+                    CorrelationHeaderName = headerName,
+                },
+            });
+
+        await transport.SendAsync(HttpMethod.Get, "/books", null, null, "Books.GetById", CancellationToken.None, "Books");
+
+        handler.LastRequest!.Headers.TryGetValues(headerName, out var values).Should().BeTrue();
+        values.Should().ContainSingle().Which.Should().Be(correlationId);
+        handler.LastRequest.Headers.Contains(SharedHttpTransport.CorrelationHeaderName).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SendAsync_EmitsActivityWithCorrelation_WhenTracingEnabled()
+    {
+        const string correlationId = "corr-trace";
+        var startedActivities = new ConcurrentQueue<Activity>();
+        using var listener = CreatePublishingSdkActivityListener(startedActivities);
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.test") };
+        var transport = CreateDiagnosticsTransport(
+            httpClient,
+            new FixedCorrelationIdProvider(correlationId),
+            new PublishingPlatformClientOptions
+            {
+                Diagnostics = new DiagnosticsOptions
+                {
+                    EnableTracing = true,
+                },
+            });
+
+        await transport.SendAsync(HttpMethod.Get, "/books/42?include=secret", null, null, "Books.GetById", CancellationToken.None, "Books");
+
+        var activity = startedActivities.Should().ContainSingle().Subject;
+        activity.OperationName.Should().Be("Books.GetById");
+        activity.Tags.Should().Contain(tag => tag.Key == "sdk.module" && tag.Value == "Books");
+        activity.Tags.Should().Contain(tag => tag.Key == "sdk.operation" && tag.Value == "Books.GetById");
+        activity.Tags.Should().Contain(tag => tag.Key == "url.path" && tag.Value == "/books/42");
+        activity.Tags.Should().Contain(tag => tag.Key == "correlation.id" && tag.Value == correlationId);
+    }
+
+    [Fact]
+    public async Task SendAsync_DoesNotEmitActivity_WhenTracingDisabled()
+    {
+        var startedActivities = new ConcurrentQueue<Activity>();
+        using var listener = CreatePublishingSdkActivityListener(startedActivities);
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.test") };
+        var transport = CreateDiagnosticsTransport(
+            httpClient,
+            new FixedCorrelationIdProvider("corr"),
+            new PublishingPlatformClientOptions
+            {
+                Diagnostics = new DiagnosticsOptions
+                {
+                    EnableTracing = false,
+                },
+            });
+
+        await transport.SendAsync(HttpMethod.Get, "/books", null, null, "Books.List", CancellationToken.None, "Books");
+
+        startedActivities.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SendAsync_EmitsStructuredLogsWithoutSensitiveValues_WhenLoggingEnabled()
+    {
+        var logger = new RecordingLogger<SharedHttpTransport>();
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.test") };
+        var transport = CreateDiagnosticsTransport(
+            httpClient,
+            new FixedCorrelationIdProvider("safe-correlation"),
+            new PublishingPlatformClientOptions
+            {
+                Diagnostics = new DiagnosticsOptions
+                {
+                    EnableLogging = true,
+                    LogRequestBody = false,
+                    LogResponseBody = false,
+                },
+            },
+            logger);
+        using var content = JsonContent.Create(new { ApiKey = "secret-api-key", Token = "secret-token" });
+        var headers = new Dictionary<string, string>
+        {
+            ["Authorization"] = "Bearer secret-token",
+            ["Idempotency-Key"] = "secret-idempotency",
+        };
+
+        await transport.SendAsync(HttpMethod.Post, "/books", content, headers, "Books.Create", CancellationToken.None, "Books");
+
+        logger.Entries.Should().HaveCount(2);
+        var joinedLogs = string.Join(Environment.NewLine, logger.Entries.Select(entry => entry.Message));
+        joinedLogs.Should().Contain("Books");
+        joinedLogs.Should().Contain("Books.Create");
+        joinedLogs.Should().Contain("safe-correlation");
+        joinedLogs.Should().NotContain("secret-api-key");
+        joinedLogs.Should().NotContain("secret-token");
+        joinedLogs.Should().NotContain("secret-idempotency");
+        joinedLogs.Should().NotContain("Authorization");
+        joinedLogs.Should().NotContain("Idempotency-Key");
+    }
+
+    [Fact]
+    public async Task SendAsync_DoesNotEmitLogs_WhenLoggingDisabled()
+    {
+        var logger = new RecordingLogger<SharedHttpTransport>();
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.test") };
+        var transport = CreateDiagnosticsTransport(
+            httpClient,
+            new FixedCorrelationIdProvider("corr"),
+            new PublishingPlatformClientOptions
+            {
+                Diagnostics = new DiagnosticsOptions
+                {
+                    EnableLogging = false,
+                },
+            },
+            logger);
+
+        await transport.SendAsync(HttpMethod.Get, "/books", null, null, "Books.List", CancellationToken.None, "Books");
+
+        logger.Entries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SendAsync_RecordsMetrics_WhenMetricsEnabled()
+    {
+        var measurements = new ConcurrentBag<string>();
+        using var listener = CreatePublishingSdkMeterListener(measurements);
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.test") };
+        var transport = CreateDiagnosticsTransport(
+            httpClient,
+            new FixedCorrelationIdProvider("corr"),
+            new PublishingPlatformClientOptions
+            {
+                Diagnostics = new DiagnosticsOptions
+                {
+                    EnableMetrics = true,
+                },
+            });
+
+        await transport.SendAsync(HttpMethod.Get, "/books", null, null, "Books.List", CancellationToken.None, "Books");
+
+        measurements.Should().Contain("publishing_platform.sdk.requests");
+        measurements.Should().Contain("publishing_platform.sdk.request.duration");
+    }
+
+    [Fact]
+    public async Task SendAsync_DoesNotRecordMetrics_WhenMetricsDisabled()
+    {
+        var measurements = new ConcurrentBag<string>();
+        using var listener = CreatePublishingSdkMeterListener(measurements);
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.test") };
+        var transport = CreateDiagnosticsTransport(
+            httpClient,
+            new FixedCorrelationIdProvider("corr"),
+            new PublishingPlatformClientOptions
+            {
+                Diagnostics = new DiagnosticsOptions
+                {
+                    EnableMetrics = false,
+                },
+            });
+
+        await transport.SendAsync(HttpMethod.Get, "/books", null, null, "Books.List", CancellationToken.None, "Books");
+
+        measurements.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SendAsync_UsesModuleDiagnosticsOverride()
+    {
+        var logger = new RecordingLogger<SharedHttpTransport>();
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.test") };
+        var transport = CreateDiagnosticsTransport(
+            httpClient,
+            new FixedCorrelationIdProvider("corr"),
+            new PublishingPlatformClientOptions
+            {
+                Diagnostics = new DiagnosticsOptions
+                {
+                    EnableLogging = true,
+                },
+                BookAnalyticsDiagnostics = new ModuleDiagnosticsOptions
+                {
+                    EnableLogging = false,
+                },
+            },
+            logger);
+
+        await transport.SendAsync(HttpMethod.Get, "/analytics", null, null, "BookAnalytics.GetSummary", CancellationToken.None, "BookAnalytics");
+
+        logger.Entries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SendAsync_LogsAndMapsFailureDiagnostics()
+    {
+        var logger = new RecordingLogger<SharedHttpTransport>();
+        var mapper = Substitute.For<IPublishingPlatformErrorMapper>();
+        mapper.Map(Arg.Any<PublishingPlatformErrorContext>())
+            .Returns(new ApiException(503, "mapped failure"));
+        using var handler = new RecordingHandler((_, _) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+            {
+                Content = JsonContent.Create(new { Message = "service unavailable" }),
+            }));
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.test") };
+        var transport = new SharedHttpTransport(
+            httpClient,
+            BuildPassThroughPipeline(),
+            new FixedCorrelationIdProvider("corr-failure"),
+            mapper,
+            new DefaultTransportRequestFactory(),
+            new DefaultTransportResponseErrorReader(),
+            new DefaultTransportErrorContextFactory(),
+            new DefaultDiagnosticsOptionsResolver(new PublishingPlatformClientOptions
+            {
+                Diagnostics = new DiagnosticsOptions
+                {
+                    EnableLogging = true,
+                },
+            }),
+            logger);
+
+        Func<Task> act = async () => await transport.SendAsync(HttpMethod.Get, "/books/42", null, null, "Books.GetById", CancellationToken.None, "Books");
+
+        await act.Should().ThrowAsync<ApiException>();
+        logger.Entries.Should().Contain(entry =>
+            entry.Message.Contains("503", StringComparison.Ordinal)
+            && entry.Message.Contains("Books.GetById", StringComparison.Ordinal)
+            && entry.Message.Contains("corr-failure", StringComparison.Ordinal));
+        mapper.Received(1).Map(Arg.Is<PublishingPlatformErrorContext>(context =>
+            context.StatusCode == 503
+            && context.OperationName == "Books.GetById"
+            && context.CorrelationId == "corr-failure"));
     }
 
     [Fact]
@@ -158,6 +448,20 @@ public sealed class ResilienceAndTransportTests
 
         act.Should().Throw<PublishingPlatformConfigurationException>()
             .WithMessage("*BaseUrl must be a valid absolute URL.*");
+    }
+
+    [Fact]
+    public void BuildBootstrapServiceProvider_ThrowsForInsecureHttpBaseUrl()
+    {
+        var options = new PublishingPlatformClientOptions
+        {
+            BaseUrl = "http://api.example.test",
+        };
+
+        Action act = () => SdkHttpClientResolver.BuildBootstrapServiceProvider(options);
+
+        act.Should().Throw<PublishingPlatformConfigurationException>()
+            .WithMessage("*BaseUrl must use HTTPS.*");
     }
 
     [Fact]
@@ -643,6 +947,57 @@ public sealed class ResilienceAndTransportTests
         return pipeline;
     }
 
+    private static SharedHttpTransport CreateDiagnosticsTransport(
+        HttpClient httpClient,
+        ICorrelationIdProvider correlationIdProvider,
+        PublishingPlatformClientOptions options,
+        ILogger<SharedHttpTransport>? logger = null)
+    {
+        return new SharedHttpTransport(
+            httpClient,
+            BuildPassThroughPipeline(),
+            correlationIdProvider,
+            new DefaultPublishingPlatformErrorMapper(),
+            new DefaultTransportRequestFactory(),
+            new DefaultTransportResponseErrorReader(),
+            new DefaultTransportErrorContextFactory(),
+            new DefaultDiagnosticsOptionsResolver(options),
+            logger ?? new RecordingLogger<SharedHttpTransport>());
+    }
+
+    private static ActivityListener CreatePublishingSdkActivityListener(ConcurrentQueue<Activity> startedActivities)
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = activitySource => activitySource.Name == "PublishingPlatform.SDK",
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            SampleUsingParentId = static (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStarted = startedActivities.Enqueue,
+        };
+
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+
+    private static MeterListener CreatePublishingSdkMeterListener(ConcurrentBag<string> measurements)
+    {
+        var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, meterListener) =>
+            {
+                if (instrument.Meter.Name == "PublishingPlatform.SDK")
+                {
+                    meterListener.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+
+        listener.SetMeasurementEventCallback<long>((instrument, _, _, _) => measurements.Add(instrument.Name));
+        listener.SetMeasurementEventCallback<double>((instrument, _, _, _) => measurements.Add(instrument.Name));
+        listener.Start();
+        return listener;
+    }
+
     private sealed class RecordingHandler : HttpMessageHandler
     {
         private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _responseFactory;
@@ -658,6 +1013,34 @@ public sealed class ResilienceAndTransportTests
         {
             LastRequest = request;
             return await _responseFactory(request, cancellationToken);
+        }
+    }
+
+    private sealed record LogEntry(LogLevel Level, string Message, Exception? Exception);
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add(new LogEntry(logLevel, formatter(state, exception), exception));
         }
     }
 


### PR DESCRIPTION
# Summary

Add centralized, opt-in diagnostics and observability for the Publishing Platform SDK.

What changed:
- Added global diagnostics configuration through `PublishingPlatformClientOptions.Diagnostics`.
- Added per-module diagnostics overrides for `Books`, `BookContent`, `BookPublishing`, `BookDistribution`, `BookAccess`, `BookAnalytics`, `BookAuditLogs`, and `Webhooks`.
- Centralized correlation ID propagation, Activity-based tracing, structured request lifecycle logging, metrics, and failure diagnostics in the shared transport path.
- Preserved safe defaults: logging, tracing, metrics, request body logging, and response body logging are disabled by default; correlation ID generation remains enabled.
- Updated diagnostics documentation and examples for consumer setup.

API impact:
- Public options surface expanded with `DiagnosticsOptions` and `ModuleDiagnosticsOptions`.
- Existing client module interfaces and operation signatures are unchanged.
- No OpenTelemetry package dependency was added; compatibility is provided through `System.Diagnostics.ActivitySource` and `System.Diagnostics.Metrics`.

# Validation

- [x] `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal`
- [x] `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal --filter "FullyQualifiedName!~OpenApiSpec_FileHash_RemainsImmutable"`

Test result evidence:
- Full suite: 231 passed, 1 failed.
- Known unrelated failure: `OpenApiSpecificationContractsTests.OpenApiSpec_FileHash_RemainsImmutable`.
- Diagnostics-focused verification excluding that known hash baseline failure: 231 passed, 0 failed, 0 skipped.

# Release Please Override (Required for releasable changes)

```text
BEGIN_COMMIT_OVERRIDE
feat(diagnostics): add centralized SDK observability
END_COMMIT_OVERRIDE
```

# Manual NuGet Publish

1. Confirm `Directory.Build.props` version equals intended release version.
2. Create matching tag `v<version>` on that exact commit.
3. Run `Publish NuGet` workflow manually with that tag.
4. Verify package version appears on NuGet.
