### PR TITLE
RPS-27 feat!: Add normalized API failure metadata and consistent exception mapping for book-centric SDK modules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ builder.Services.AddPublishingPlatformClient(options =>
 
 ### Optional: custom error mapper
 
-Use a custom mapper to throw domain-specific exceptions with request context.
+Use a custom mapper to throw domain-specific exceptions with normalized request context.
 
 ```csharp
 using PublishingPlatform.SDK.Abstractions;
@@ -473,10 +473,12 @@ public sealed class PublishingErrorMapper : IPublishingPlatformErrorMapper
     {
         if (context.StatusCode == 404 && context.RelativePath.StartsWith("/books/", StringComparison.Ordinal))
         {
-            return new InvalidOperationException($"Book was not found. Path: {context.RelativePath}");
+        return new InvalidOperationException(
+            $"Book was not found. Code: {context.ErrorCode}. Request: {context.RequestId}. Path: {context.RelativePath}");
         }
 
-        return new Exception($"API call failed ({context.StatusCode}) for {context.Method} {context.RelativePath}: {context.Message}");
+    return new Exception(
+        $"API call failed ({context.StatusCode}, {context.ErrorCode}) for {context.Method} {context.RelativePath}: {context.Message}");
     }
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,7 +63,7 @@ When enabled, resilience can include retry, circuit breaker, attempt timeout, an
 
 ## Error Mapping
 
-Error handling is centralized through `IPublishingPlatformErrorMapper`. The default mapper returns an `ApiException` with the HTTP status code and normalized message. Consumers can provide a custom mapper for domain-specific exception types.
+Error handling is centralized through `IPublishingPlatformErrorMapper`. The default mapper returns exceptions derived from `PublishingPlatformApiException`, with HTTP status code, normalized error code, request ID, correlation ID, operation name, method, path, and normalized message. Consumers can provide a custom mapper for domain-specific exception types.
 
 The error handling contract should stay module-independent so every client follows the same failure rules.
 

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -63,7 +63,7 @@ Status: Accepted.
 
 The SDK uses `IPublishingPlatformErrorMapper` as the single extension point for API error conversion.
 
-The default mapper returns `ApiException`. Consumers can replace it when they need domain-specific exceptions, but the transport should still provide the same normalized context.
+The default mapper returns `ApiException` for generic API failures and typed book exceptions for common book-centric HTTP failures. Consumers can replace it when they need domain-specific exceptions, but the transport should still provide the same normalized context.
 
 ## Provider-Hidden Query Architecture
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -7,7 +7,7 @@ The SDK centralizes error handling so consumers get consistent failures across a
 All shared HTTP calls pass through the internal transport. When the API returns a non-success HTTP status code, the transport:
 
 1. Reads the response body as a structured transport error payload when possible.
-2. Falls back to a generic message when the body is missing, malformed, or not JSON.
+2. Falls back to normalized message and error-code defaults when the body is missing, malformed, or not JSON.
 3. Creates a `PublishingPlatformErrorContext`.
 4. Throws the exception returned by `IPublishingPlatformErrorMapper`.
 
@@ -17,9 +17,19 @@ The error context includes:
 - `RelativePath`
 - `StatusCode`
 - `Message`
+- `ErrorCode`
+- `RequestId`
 - `CorrelationId`
+- `OperationName`
 
-The default mapper returns an `ApiException` that includes the HTTP status code and normalized message.
+The default mapper returns exceptions that derive from `PublishingPlatformApiException`, including `ApiException` for generic API failures and book-specific exceptions for known book-centric failure categories. These exceptions preserve the HTTP status code, normalized error code, request ID, correlation ID, operation name, method, path, and message.
+
+Book-centric modules include `Books`, `BookContent`, `BookPublishing`, `BookDistribution`, `BookAccess`, `BookAnalytics`, and `BookAuditLogs`. For these modules, the default mapper returns:
+
+- `BookNotFoundException` for `404`
+- `BookConflictException` for `409` and `412`
+- `BookRateLimitedException` for `429`
+- `ApiException` for other HTTP failures
 
 ## Fallback Messages
 
@@ -29,13 +39,15 @@ If the response body does not contain a usable error message, the SDK returns a 
 HTTP {statusCode} returned by Publishing Platform API.
 ```
 
+If the response body does not contain a usable error code, the SDK uses `http_{statusCode}`.
+
 This avoids exposing raw, unstructured response bodies while still giving consumers enough information to understand the failure category.
 
 ## Custom Error Mapping
 
 Consumers can provide a custom `IPublishingPlatformErrorMapper` through `PublishingPlatformClientOptions` or `PublishingPlatformClientBuilder.WithErrorMapper`.
 
-Custom mappers should use `PublishingPlatformErrorContext` to convert API failures into application-specific exceptions. They should preserve important context such as status code, request path, method, and correlation ID.
+Custom mappers should use `PublishingPlatformErrorContext` to convert API failures into application-specific exceptions. They should preserve important context such as status code, normalized error code, request ID, request path, method, operation name, and correlation ID.
 
 ## Cancellation
 

--- a/src/PublishingPlatform.SDK/Abstractions/PublishingPlatformErrorContext.cs
+++ b/src/PublishingPlatform.SDK/Abstractions/PublishingPlatformErrorContext.cs
@@ -1,16 +1,47 @@
 namespace PublishingPlatform.SDK.Abstractions;
 
+/// <summary>
+/// Describes a normalized API failure before it is mapped to an SDK exception.
+/// </summary>
 public sealed class PublishingPlatformErrorContext
 {
+    /// <summary>
+    /// Gets the HTTP method used by the failed request.
+    /// </summary>
     public required HttpMethod Method { get; init; }
 
+    /// <summary>
+    /// Gets the relative request path used by the failed request.
+    /// </summary>
     public required string RelativePath { get; init; }
 
+    /// <summary>
+    /// Gets the HTTP status code returned by the API.
+    /// </summary>
     public required int StatusCode { get; init; }
 
+    /// <summary>
+    /// Gets the normalized failure message.
+    /// </summary>
     public required string Message { get; init; }
 
+    /// <summary>
+    /// Gets the normalized API error code.
+    /// </summary>
+    public required string ErrorCode { get; init; }
+
+    /// <summary>
+    /// Gets the API request identifier, when one is returned by the API.
+    /// </summary>
+    public string? RequestId { get; init; }
+
+    /// <summary>
+    /// Gets the request correlation identifier.
+    /// </summary>
     public string? CorrelationId { get; init; }
 
+    /// <summary>
+    /// Gets the SDK operation name associated with the failed request.
+    /// </summary>
     public string? OperationName { get; init; }
 }

--- a/src/PublishingPlatform.SDK/Exceptions/BookConflictException.cs
+++ b/src/PublishingPlatform.SDK/Exceptions/BookConflictException.cs
@@ -1,9 +1,11 @@
+using PublishingPlatform.SDK.Abstractions;
+
 namespace PublishingPlatform.SDK.Exceptions;
 
 /// <summary>
 /// Represents a conflict failure for book mutations.
 /// </summary>
-public sealed class BookConflictException : Exception
+public sealed class BookConflictException : PublishingPlatformApiException
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="BookConflictException"/> class.
@@ -11,7 +13,26 @@ public sealed class BookConflictException : Exception
     /// <param name="bookId">The book identifier associated with the conflict.</param>
     /// <param name="message">The failure message.</param>
     public BookConflictException(string bookId, string message)
-        : base(message)
+        : base(409, message)
+    {
+        BookId = bookId;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BookConflictException"/> class.
+    /// </summary>
+    /// <param name="bookId">The book identifier associated with the conflict.</param>
+    /// <param name="context">The normalized error context.</param>
+    public BookConflictException(string bookId, PublishingPlatformErrorContext context)
+        : base(
+            context.StatusCode,
+            context.Message,
+            context.ErrorCode,
+            context.RequestId,
+            context.CorrelationId,
+            context.OperationName,
+            context.Method,
+            context.RelativePath)
     {
         BookId = bookId;
     }

--- a/src/PublishingPlatform.SDK/Exceptions/BookNotFoundException.cs
+++ b/src/PublishingPlatform.SDK/Exceptions/BookNotFoundException.cs
@@ -1,9 +1,11 @@
+using PublishingPlatform.SDK.Abstractions;
+
 namespace PublishingPlatform.SDK.Exceptions;
 
 /// <summary>
 /// Represents a not found failure for a book resource.
 /// </summary>
-public sealed class BookNotFoundException : Exception
+public sealed class BookNotFoundException : PublishingPlatformApiException
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="BookNotFoundException"/> class.
@@ -11,7 +13,26 @@ public sealed class BookNotFoundException : Exception
     /// <param name="bookId">The missing book identifier.</param>
     /// <param name="message">The failure message.</param>
     public BookNotFoundException(string bookId, string message)
-        : base(message)
+        : base(404, message)
+    {
+        BookId = bookId;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BookNotFoundException"/> class.
+    /// </summary>
+    /// <param name="bookId">The missing book identifier.</param>
+    /// <param name="context">The normalized error context.</param>
+    public BookNotFoundException(string bookId, PublishingPlatformErrorContext context)
+        : base(
+            context.StatusCode,
+            context.Message,
+            context.ErrorCode,
+            context.RequestId,
+            context.CorrelationId,
+            context.OperationName,
+            context.Method,
+            context.RelativePath)
     {
         BookId = bookId;
     }

--- a/src/PublishingPlatform.SDK/Exceptions/BookRateLimitedException.cs
+++ b/src/PublishingPlatform.SDK/Exceptions/BookRateLimitedException.cs
@@ -1,16 +1,35 @@
+using PublishingPlatform.SDK.Abstractions;
+
 namespace PublishingPlatform.SDK.Exceptions;
 
 /// <summary>
 /// Represents rate limiting failures for book operations.
 /// </summary>
-public sealed class BookRateLimitedException : Exception
+public sealed class BookRateLimitedException : PublishingPlatformApiException
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="BookRateLimitedException"/> class.
     /// </summary>
     /// <param name="message">The failure message.</param>
     public BookRateLimitedException(string message)
-        : base(message)
+        : base(429, message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BookRateLimitedException"/> class.
+    /// </summary>
+    /// <param name="context">The normalized error context.</param>
+    public BookRateLimitedException(PublishingPlatformErrorContext context)
+        : base(
+            context.StatusCode,
+            context.Message,
+            context.ErrorCode,
+            context.RequestId,
+            context.CorrelationId,
+            context.OperationName,
+            context.Method,
+            context.RelativePath)
     {
     }
 }

--- a/src/PublishingPlatform.SDK/Exceptions/PublishingPlatformApiException.cs
+++ b/src/PublishingPlatform.SDK/Exceptions/PublishingPlatformApiException.cs
@@ -1,0 +1,73 @@
+namespace PublishingPlatform.SDK.Exceptions;
+
+/// <summary>
+/// Represents a normalized API failure returned by the Publishing Platform API.
+/// </summary>
+public class PublishingPlatformApiException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PublishingPlatformApiException"/> class.
+    /// </summary>
+    /// <param name="statusCode">The HTTP status code returned by the API.</param>
+    /// <param name="message">The normalized failure message.</param>
+    /// <param name="errorCode">The normalized API error code.</param>
+    /// <param name="requestId">The API request identifier, when available.</param>
+    /// <param name="correlationId">The correlation identifier associated with the request.</param>
+    /// <param name="operationName">The SDK operation name associated with the request.</param>
+    /// <param name="method">The HTTP method used by the request.</param>
+    /// <param name="relativePath">The relative request path.</param>
+    public PublishingPlatformApiException(
+        int statusCode,
+        string message,
+        string? errorCode = null,
+        string? requestId = null,
+        string? correlationId = null,
+        string? operationName = null,
+        HttpMethod? method = null,
+        string? relativePath = null)
+        : base(message)
+    {
+        StatusCode = statusCode;
+        ErrorCode = string.IsNullOrWhiteSpace(errorCode) ? $"http_{statusCode}" : errorCode;
+        RequestId = requestId;
+        CorrelationId = correlationId;
+        OperationName = operationName;
+        Method = method;
+        RelativePath = relativePath;
+    }
+
+    /// <summary>
+    /// Gets the HTTP status code returned by the API.
+    /// </summary>
+    public int StatusCode { get; }
+
+    /// <summary>
+    /// Gets the normalized API error code.
+    /// </summary>
+    public string ErrorCode { get; }
+
+    /// <summary>
+    /// Gets the API request identifier, when available.
+    /// </summary>
+    public string? RequestId { get; }
+
+    /// <summary>
+    /// Gets the correlation identifier associated with the request.
+    /// </summary>
+    public string? CorrelationId { get; }
+
+    /// <summary>
+    /// Gets the SDK operation name associated with the request.
+    /// </summary>
+    public string? OperationName { get; }
+
+    /// <summary>
+    /// Gets the HTTP method used by the request.
+    /// </summary>
+    public HttpMethod? Method { get; }
+
+    /// <summary>
+    /// Gets the relative request path.
+    /// </summary>
+    public string? RelativePath { get; }
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/Errors/ApiException.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Errors/ApiException.cs
@@ -1,12 +1,37 @@
-﻿namespace PublishingPlatform.SDK.Infrastructure.Errors;
+using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Exceptions;
 
-public sealed class ApiException : Exception
+namespace PublishingPlatform.SDK.Infrastructure.Errors;
+
+/// <summary>
+/// Represents a generic normalized API failure.
+/// </summary>
+public sealed class ApiException : PublishingPlatformApiException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApiException"/> class.
+    /// </summary>
+    /// <param name="statusCode">The HTTP status code returned by the API.</param>
+    /// <param name="message">The normalized failure message.</param>
     public ApiException(int statusCode, string message)
-        : base(message)
+        : base(statusCode, message)
     {
-        StatusCode = statusCode;
     }
 
-    public int StatusCode { get; }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ApiException"/> class.
+    /// </summary>
+    /// <param name="context">The normalized error context.</param>
+    public ApiException(PublishingPlatformErrorContext context)
+        : base(
+            context.StatusCode,
+            context.Message,
+            context.ErrorCode,
+            context.RequestId,
+            context.CorrelationId,
+            context.OperationName,
+            context.Method,
+            context.RelativePath)
+    {
+    }
 }

--- a/src/PublishingPlatform.SDK/Infrastructure/Errors/DefaultPublishingPlatformErrorMapper.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Errors/DefaultPublishingPlatformErrorMapper.cs
@@ -3,40 +3,120 @@ using PublishingPlatform.SDK.Exceptions;
 
 namespace PublishingPlatform.SDK.Infrastructure.Errors;
 
+/// <summary>
+/// Maps normalized Publishing Platform API failures to SDK exception types.
+/// </summary>
 internal sealed class DefaultPublishingPlatformErrorMapper : IPublishingPlatformErrorMapper
 {
+    private static readonly string[] BookCentricOperationPrefixes =
+    [
+        "Books",
+        "BookContent",
+        "BookPublishing",
+        "BookDistribution",
+        "BookAccess",
+        "BookAnalytics",
+        "BookAuditLogs",
+    ];
+
     public Exception Map(PublishingPlatformErrorContext context)
     {
-        if (context.RelativePath.StartsWith("/books", StringComparison.OrdinalIgnoreCase))
+        if (IsBookCentric(context))
         {
-            if (context.StatusCode == 404)
+            var bookId = ExtractBookId(context.RelativePath);
+            return context.StatusCode switch
             {
-                return new BookNotFoundException(ExtractBookId(context.RelativePath), context.Message);
-            }
+                404 => new BookNotFoundException(bookId, context),
+                409 or 412 => new BookConflictException(bookId, context),
+                429 => new BookRateLimitedException(context),
+                _ => new ApiException(context),
+            };
+        }
 
-            if (context.StatusCode is 409 or 412)
-            {
-                return new BookConflictException(ExtractBookId(context.RelativePath), context.Message);
-            }
+        return new ApiException(context);
+    }
 
-            if (context.StatusCode == 429)
+    private static bool IsBookCentric(PublishingPlatformErrorContext context)
+    {
+        if (StartsWithOperationPrefix(context.OperationName, "Webhooks"))
+        {
+            return false;
+        }
+
+        foreach (var prefix in BookCentricOperationPrefixes)
+        {
+            if (StartsWithOperationPrefix(context.OperationName, prefix))
             {
-                return new BookRateLimitedException(context.Message);
+                return true;
             }
         }
 
-        return ErrorMapper.Map(context.StatusCode, context.Message);
+        if (StartsWithBookCentricPath(context.RelativePath))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool StartsWithBookCentricPath(string relativePath)
+    {
+        var path = GetPathWithoutQuery(relativePath);
+        return path.StartsWith("/books", StringComparison.OrdinalIgnoreCase)
+            || path.StartsWith("/book-access", StringComparison.OrdinalIgnoreCase)
+            || path.StartsWith("/book-analytics", StringComparison.OrdinalIgnoreCase)
+            || path.StartsWith("/book-audit-logs", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool StartsWithOperationPrefix(string? operationName, string prefix)
+    {
+        return operationName is not null
+            && (operationName.Equals(prefix, StringComparison.OrdinalIgnoreCase)
+                || (operationName.Length > prefix.Length
+                    && operationName[prefix.Length] == '.'
+                    && operationName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)));
     }
 
     private static string ExtractBookId(string relativePath)
     {
-        var path = relativePath.Trim('/');
+        var path = GetPathWithoutQuery(relativePath).Trim('/');
         var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
-        if (segments.Length < 2)
+        if (segments.Length >= 2 && segments[0].Equals("books", StringComparison.OrdinalIgnoreCase))
         {
-            return string.Empty;
+            return Uri.UnescapeDataString(segments[1]);
         }
 
-        return segments[1];
+        return ExtractQueryValue(relativePath, "bookId") ?? string.Empty;
+    }
+
+    private static string GetPathWithoutQuery(string relativePath)
+    {
+        var queryStart = relativePath.IndexOf('?', StringComparison.Ordinal);
+        return queryStart < 0 ? relativePath : relativePath[..queryStart];
+    }
+
+    private static string? ExtractQueryValue(string relativePath, string key)
+    {
+        var queryStart = relativePath.IndexOf('?', StringComparison.Ordinal);
+        if (queryStart < 0 || queryStart == relativePath.Length - 1)
+        {
+            return null;
+        }
+
+        var query = relativePath[(queryStart + 1)..];
+        foreach (var pair in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var separatorIndex = pair.IndexOf('=', StringComparison.Ordinal);
+            var candidateKey = separatorIndex < 0 ? pair : pair[..separatorIndex];
+            if (!Uri.UnescapeDataString(candidateKey).Equals(key, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var value = separatorIndex < 0 ? string.Empty : pair[(separatorIndex + 1)..];
+            return Uri.UnescapeDataString(value);
+        }
+
+        return null;
     }
 }

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/Errors/DefaultTransportErrorContextFactory.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/Errors/DefaultTransportErrorContextFactory.cs
@@ -8,7 +8,7 @@ internal sealed class DefaultTransportErrorContextFactory : ITransportErrorConte
         HttpMethod method,
         string relativePath,
         int statusCode,
-        string message,
+        NormalizedTransportError error,
         string? correlationId,
         string? operationName)
     {
@@ -17,8 +17,10 @@ internal sealed class DefaultTransportErrorContextFactory : ITransportErrorConte
             Method = method,
             RelativePath = relativePath,
             StatusCode = statusCode,
-            Message = message,
-            CorrelationId = correlationId,
+            Message = error.Message,
+            ErrorCode = error.ErrorCode,
+            RequestId = error.RequestId,
+            CorrelationId = string.IsNullOrWhiteSpace(error.CorrelationId) ? correlationId : error.CorrelationId,
             OperationName = operationName,
         };
     }

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/Errors/DefaultTransportResponseErrorReader.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/Errors/DefaultTransportResponseErrorReader.cs
@@ -5,7 +5,7 @@ namespace PublishingPlatform.SDK.Infrastructure.Transport.Errors;
 
 internal sealed class DefaultTransportResponseErrorReader : ITransportResponseErrorReader
 {
-    public async Task<string> ReadAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    public async Task<NormalizedTransportError> ReadAsync(HttpResponseMessage response, CancellationToken cancellationToken)
     {
         TransportErrorResponse? payload = null;
         try
@@ -17,11 +17,20 @@ internal sealed class DefaultTransportResponseErrorReader : ITransportResponseEr
             // Fallback message is returned below.
         }
 
-        if (payload is not null && !string.IsNullOrWhiteSpace(payload.Message))
-        {
-            return payload.Message;
-        }
+        var statusCode = (int)response.StatusCode;
+        var message = payload is not null && !string.IsNullOrWhiteSpace(payload.Message)
+            ? payload.Message
+            : $"HTTP {statusCode} returned by Publishing Platform API.";
+        var errorCode = payload is not null && !string.IsNullOrWhiteSpace(payload.ErrorCode)
+            ? payload.ErrorCode
+            : $"http_{statusCode}";
 
-        return $"HTTP {(int)response.StatusCode} returned by Publishing Platform API.";
+        return new NormalizedTransportError
+        {
+            Message = message,
+            ErrorCode = errorCode,
+            CorrelationId = payload?.CorrelationId,
+            RequestId = payload?.RequestId,
+        };
     }
 }

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/Errors/ITransportErrorContextFactory.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/Errors/ITransportErrorContextFactory.cs
@@ -8,7 +8,7 @@ internal interface ITransportErrorContextFactory
         HttpMethod method,
         string relativePath,
         int statusCode,
-        string message,
+        NormalizedTransportError error,
         string? correlationId,
         string? operationName);
 }

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/Errors/ITransportResponseErrorReader.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/Errors/ITransportResponseErrorReader.cs
@@ -2,5 +2,5 @@ namespace PublishingPlatform.SDK.Infrastructure.Transport.Errors;
 
 internal interface ITransportResponseErrorReader
 {
-    Task<string> ReadAsync(HttpResponseMessage response, CancellationToken cancellationToken);
+    Task<NormalizedTransportError> ReadAsync(HttpResponseMessage response, CancellationToken cancellationToken);
 }

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/Errors/NormalizedTransportError.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/Errors/NormalizedTransportError.cs
@@ -1,0 +1,15 @@
+namespace PublishingPlatform.SDK.Infrastructure.Transport.Errors;
+
+/// <summary>
+/// Carries normalized API failure fields read from a transport response.
+/// </summary>
+internal sealed class NormalizedTransportError
+{
+    public required string Message { get; init; }
+
+    public required string ErrorCode { get; init; }
+
+    public string? CorrelationId { get; init; }
+
+    public string? RequestId { get; init; }
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransport.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransport.cs
@@ -173,12 +173,12 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
             LogRequestCompleted(diagnosticsContext, response, elapsed);
             RecordMetrics(diagnosticsContext, response, elapsed, attempts);
 
-            var message = await _responseErrorReader.ReadAsync(response, cancellationToken).ConfigureAwait(false);
+            var error = await _responseErrorReader.ReadAsync(response, cancellationToken).ConfigureAwait(false);
             var context = _errorContextFactory.Create(
                 method,
                 relativePath,
                 (int)response.StatusCode,
-                message,
+                error,
                 correlationId,
                 operationName);
 

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/TransportErrorResponse.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/TransportErrorResponse.cs
@@ -3,4 +3,10 @@ namespace PublishingPlatform.SDK.Infrastructure.Transport;
 internal sealed class TransportErrorResponse
 {
     public string? Message { get; set; }
+
+    public string? ErrorCode { get; set; }
+
+    public string? CorrelationId { get; set; }
+
+    public string? RequestId { get; set; }
 }

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/ErrorMappingTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/ErrorMappingTests.cs
@@ -1,0 +1,113 @@
+using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Infrastructure.Errors;
+
+namespace PublishingPlatform.SDK.Tests.Infrastructure;
+
+public sealed class ErrorMappingTests
+{
+    [Fact]
+    public void Map_ReturnsBookNotFoundException_WithNormalizedMetadata()
+    {
+        var mapper = new DefaultPublishingPlatformErrorMapper();
+        var context = CreateContext(404, "/books/book-27", "Books.GetById");
+
+        var exception = mapper.Map(context);
+
+        var typed = exception.Should().BeOfType<BookNotFoundException>().Subject;
+        typed.BookId.Should().Be("book-27");
+        AssertApiMetadata(typed, context);
+    }
+
+    [Theory]
+    [InlineData(409)]
+    [InlineData(412)]
+    public void Map_ReturnsBookConflictException_ForConflictStatuses(int statusCode)
+    {
+        var mapper = new DefaultPublishingPlatformErrorMapper();
+        var context = CreateContext(statusCode, "/books/book-27/publishing/publish", "BookPublishing.Publish");
+
+        var exception = mapper.Map(context);
+
+        var typed = exception.Should().BeOfType<BookConflictException>().Subject;
+        typed.BookId.Should().Be("book-27");
+        AssertApiMetadata(typed, context);
+    }
+
+    [Fact]
+    public void Map_ReturnsBookRateLimitedException_ForBookCentricRateLimit()
+    {
+        var mapper = new DefaultPublishingPlatformErrorMapper();
+        var context = CreateContext(429, "/book-analytics/summary?bookId=book-27", "BookAnalytics.GetSummary");
+
+        var exception = mapper.Map(context);
+
+        var typed = exception.Should().BeOfType<BookRateLimitedException>().Subject;
+        AssertApiMetadata(typed, context);
+    }
+
+    [Fact]
+    public void Map_ExtractsBookId_FromQueryStringForBookCentricModules()
+    {
+        var mapper = new DefaultPublishingPlatformErrorMapper();
+        var context = CreateContext(404, "/book-audit-logs?page=1&bookId=book%2042", "BookAuditLogs.List");
+
+        var exception = mapper.Map(context);
+
+        exception.Should().BeOfType<BookNotFoundException>()
+            .Subject.BookId.Should().Be("book 42");
+    }
+
+    [Fact]
+    public void Map_ReturnsGenericApiException_ForBookCentricUnknownStatus()
+    {
+        var mapper = new DefaultPublishingPlatformErrorMapper();
+        var context = CreateContext(500, "/books/book-27", "Books.GetById");
+
+        var exception = mapper.Map(context);
+
+        var typed = exception.Should().BeOfType<ApiException>().Subject;
+        AssertApiMetadata(typed, context);
+    }
+
+    [Fact]
+    public void Map_ReturnsGenericApiException_ForWebhooksEvenWhenPathContainsBooks()
+    {
+        var mapper = new DefaultPublishingPlatformErrorMapper();
+        var context = CreateContext(404, "/webhooks/books", "Webhooks.List");
+
+        var exception = mapper.Map(context);
+
+        exception.Should().BeOfType<ApiException>();
+    }
+
+    private static PublishingPlatformErrorContext CreateContext(
+        int statusCode,
+        string relativePath,
+        string operationName)
+    {
+        return new PublishingPlatformErrorContext
+        {
+            Method = HttpMethod.Get,
+            RelativePath = relativePath,
+            StatusCode = statusCode,
+            Message = "normalized message",
+            ErrorCode = "book.failure",
+            RequestId = "req-27",
+            CorrelationId = "corr-27",
+            OperationName = operationName,
+        };
+    }
+
+    private static void AssertApiMetadata(PublishingPlatformApiException exception, PublishingPlatformErrorContext context)
+    {
+        exception.StatusCode.Should().Be(context.StatusCode);
+        exception.Message.Should().Be(context.Message);
+        exception.ErrorCode.Should().Be(context.ErrorCode);
+        exception.RequestId.Should().Be(context.RequestId);
+        exception.CorrelationId.Should().Be(context.CorrelationId);
+        exception.OperationName.Should().Be(context.OperationName);
+        exception.Method.Should().Be(context.Method);
+        exception.RelativePath.Should().Be(context.RelativePath);
+    }
+}

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/TransportCollaboratorsTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/TransportCollaboratorsTests.cs
@@ -28,33 +28,70 @@ public sealed class TransportCollaboratorsTests
             Content = new StringContent("oops"),
         };
 
-        var message = await reader.ReadAsync(response, CancellationToken.None);
+        var error = await reader.ReadAsync(response, CancellationToken.None);
 
-        message.Should().Contain("HTTP 502");
+        error.Message.Should().Be("HTTP 502 returned by Publishing Platform API.");
+        error.ErrorCode.Should().Be("http_502");
+        error.RequestId.Should().BeNull();
+        error.CorrelationId.Should().BeNull();
     }
 
     [Fact]
-    public async Task ResponseErrorReader_UsesPayloadMessage_WhenPresent()
+    public async Task ResponseErrorReader_UsesNormalizedPayloadFields_WhenPresent()
     {
         var reader = new DefaultTransportResponseErrorReader();
         using var response = new HttpResponseMessage(HttpStatusCode.BadRequest)
         {
-            Content = JsonContent.Create(new { Message = "invalid" }),
+            Content = JsonContent.Create(new
+            {
+                Message = "invalid",
+                ErrorCode = "book.invalid",
+                RequestId = "req-1",
+                CorrelationId = "corr-from-api",
+            }),
         };
 
-        var message = await reader.ReadAsync(response, CancellationToken.None);
+        var error = await reader.ReadAsync(response, CancellationToken.None);
 
-        message.Should().Be("invalid");
+        error.Message.Should().Be("invalid");
+        error.ErrorCode.Should().Be("book.invalid");
+        error.RequestId.Should().Be("req-1");
+        error.CorrelationId.Should().Be("corr-from-api");
     }
 
     [Fact]
-    public void ErrorContextFactory_PreservesOperationName()
+    public async Task ResponseErrorReader_FallsBackForUnknownPayloadShape()
+    {
+        var reader = new DefaultTransportResponseErrorReader();
+        using var response = new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = JsonContent.Create(new { Detail = "shape not normalized" }),
+        };
+
+        var error = await reader.ReadAsync(response, CancellationToken.None);
+
+        error.Message.Should().Be("HTTP 500 returned by Publishing Platform API.");
+        error.ErrorCode.Should().Be("http_500");
+    }
+
+    [Fact]
+    public void ErrorContextFactory_PreservesNormalizedMetadata()
     {
         var factory = new DefaultTransportErrorContextFactory();
+        var error = new NormalizedTransportError
+        {
+            Message = "x",
+            ErrorCode = "book.failed",
+            RequestId = "req-1",
+            CorrelationId = "api-corr",
+        };
 
-        PublishingPlatformErrorContext context = factory.Create(HttpMethod.Get, "/books", 500, "x", "corr", "Books.List");
+        PublishingPlatformErrorContext context = factory.Create(HttpMethod.Get, "/books", 500, error, "generated-corr", "Books.List");
 
         context.OperationName.Should().Be("Books.List");
-        context.CorrelationId.Should().Be("corr");
+        context.CorrelationId.Should().Be("api-corr");
+        context.RequestId.Should().Be("req-1");
+        context.ErrorCode.Should().Be("book.failed");
+        context.Message.Should().Be("x");
     }
 }


### PR DESCRIPTION
# Summary

Add normalized API failure metadata and consistent exception mapping for book-centric SDK modules.

What changed:
- Expanded the shared transport error path to normalize API error payload fields: message, error code, request ID, and correlation ID.
- Added `PublishingPlatformApiException` as the common API exception metadata shape, while preserving existing exception constructors.
- Updated default mapping so `Books`, `BookContent`, `BookPublishing`, `BookDistribution`, `BookAccess`, `BookAnalytics`, and `BookAuditLogs` map common HTTP failures consistently.
- Updated error-handling documentation and the README custom mapper example to describe the richer context.

API impact:
- Public exception metadata is additive: API exceptions now expose status code, error code, request ID, correlation ID, operation name, method, and relative path.
- Existing module interfaces and operation signatures are unchanged.
- Existing exception names and basic constructors remain source-compatible.

Commit message:

```text
feat(errors): normalize API failure metadata
```

PR title:

```text
RPS-27 feat(errors): normalize API failure metadata
```

# Validation

- [x] `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal`
- [x] Optimization scan on changed C# files; no critical findings, one safe mapper cleanup applied.

Test result evidence:
- Full suite: 240 passed, 0 failed, 0 skipped.

# Release Please Override (Required for releasable changes)

```text
BEGIN_COMMIT_OVERRIDE
feat(errors): normalize API failure metadata
END_COMMIT_OVERRIDE
```

# Manual NuGet Publish

1. Confirm `Directory.Build.props` version equals intended release version.
2. Create matching tag `v<version>` on that exact commit.
3. Run `Publish NuGet` workflow manually with that tag.
4. Verify package version appears on NuGet.
