### PR TITLE
RPS-28 fix:  Harden retry/backoff behavior for transient scenarios by enforcing idempotency safety for non-idempotent operations while keeping resilience opt-in.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.2.1</Version>
+    <Version>0.2.2</Version>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -397,7 +397,8 @@ var client = PublishingPlatformClientBuilder.Create(new PublishingPlatformClient
         {
             Enabled = true,
             MaxRetryAttempts = 5,
-            BaseDelay = TimeSpan.FromMilliseconds(250)
+            BaseDelay = TimeSpan.FromMilliseconds(250),
+            UseJitter = true
         },
         AttemptTimeout = new TimeoutResilienceOptions
         {
@@ -430,11 +431,14 @@ var client = PublishingPlatformClientBuilder.Create(new PublishingPlatformClient
             Enabled = true,
             MaxRetryAttempts = 3,
             BaseDelay = TimeSpan.FromMilliseconds(200),
-            RetryNonIdempotentMethods = true
+            RetryNonIdempotentMethods = true,
+            UseJitter = true
         }
     }
 }).Build();
 ```
+
+When non-idempotent retries are enabled, the SDK retries only safe transient statuses (`429`, `503`) and only when an `Idempotency-Key` is present with replayable request content.
 
 ## ASP.NET Core registration (Options pattern)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,7 +59,7 @@ This central transport is intentional. It reduces per-client drift and makes fut
 
 Resilience is opt-in. The default behavior is a no-op pipeline so consumers do not get retries or circuit breaking unless they configure them.
 
-When enabled, resilience can include retry, circuit breaker, attempt timeout, and total timeout behavior. Retry behavior must remain conservative: transient failures can be retried, while unsafe operations need idempotency-aware handling before retries are expanded.
+When enabled, resilience can include retry, circuit breaker, attempt timeout, and total timeout behavior. Retry behavior remains conservative: transient failures can be retried, while non-idempotent operations (`POST`, `PATCH`) require explicit opt-in, an idempotency key, and replay-safe content before retries are applied.
 
 ## Error Mapping
 

--- a/examples/RetryPolicy/README.md
+++ b/examples/RetryPolicy/README.md
@@ -5,6 +5,8 @@ Use `RetryPolicyExample.csx` to configure retry behavior with explicit defaults:
 - `RetryNonIdempotentMethods = false`:
   retries only idempotent requests (`GET`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, `TRACE`).
 - `RetryNonIdempotentMethods = true`:
-  allows retries for `POST` and `PATCH` using the SDK's safer transient set.
+  allows retries for `POST` and `PATCH` using the SDK's safer transient set when idempotency key and replay-safe content requirements are met.
+- `UseJitter = true`:
+  keeps exponential backoff randomized in production; set to `false` for deterministic tests when needed.
 
 This keeps non-idempotent retries explicit and opt-in.

--- a/examples/RetryPolicy/RetryPolicyExample.csx
+++ b/examples/RetryPolicy/RetryPolicyExample.csx
@@ -15,7 +15,8 @@ var clientWithIdempotentRetriesOnly = PublishingPlatformClientBuilder.Create(new
             Enabled = true,
             MaxRetryAttempts = 3,
             BaseDelay = TimeSpan.FromMilliseconds(200),
-            RetryNonIdempotentMethods = false
+            RetryNonIdempotentMethods = false,
+            UseJitter = true
         }
     }
 }).Build();
@@ -32,7 +33,8 @@ var clientWithPostPatchRetries = PublishingPlatformClientBuilder.Create(new Publ
             Enabled = true,
             MaxRetryAttempts = 3,
             BaseDelay = TimeSpan.FromMilliseconds(200),
-            RetryNonIdempotentMethods = true
+            RetryNonIdempotentMethods = true,
+            UseJitter = true
         }
     }
 }).Build();

--- a/src/PublishingPlatform.SDK/Abstractions/PublishingPlatformResilienceContext.cs
+++ b/src/PublishingPlatform.SDK/Abstractions/PublishingPlatformResilienceContext.cs
@@ -1,6 +1,22 @@
 namespace PublishingPlatform.SDK.Abstractions;
 
+/// <summary>
+/// Describes request characteristics used by resilience policies.
+/// </summary>
 public sealed class PublishingPlatformResilienceContext
 {
+    /// <summary>
+    /// Gets the HTTP method for the logical operation.
+    /// </summary>
     public required HttpMethod Method { get; init; }
+
+    /// <summary>
+    /// Gets whether the request includes an idempotency key header.
+    /// </summary>
+    public bool HasIdempotencyKey { get; init; }
+
+    /// <summary>
+    /// Gets whether request content can be replayed safely across retries.
+    /// </summary>
+    public bool CanReplayContent { get; init; } = true;
 }

--- a/src/PublishingPlatform.SDK/Clients/BookContent/Requests/DefaultBookContentRequestHeadersFactory.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookContent/Requests/DefaultBookContentRequestHeadersFactory.cs
@@ -1,3 +1,5 @@
+using PublishingPlatform.SDK.Infrastructure.Transport;
+
 namespace PublishingPlatform.SDK.Clients.BookContent.Requests;
 
 internal sealed class DefaultBookContentRequestHeadersFactory : IBookContentRequestHeadersFactory
@@ -11,7 +13,7 @@ internal sealed class DefaultBookContentRequestHeadersFactory : IBookContentRequ
 
         return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            ["Idempotency-Key"] = idempotencyKey,
+            [TransportHeaderNames.IdempotencyKey] = idempotencyKey,
         };
     }
 }

--- a/src/PublishingPlatform.SDK/Clients/BookDistribution/Requests/DefaultBookDistributionRequestHeadersFactory.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookDistribution/Requests/DefaultBookDistributionRequestHeadersFactory.cs
@@ -1,3 +1,5 @@
+using PublishingPlatform.SDK.Infrastructure.Transport;
+
 namespace PublishingPlatform.SDK.Clients.BookDistribution.Requests;
 
 /// <summary>
@@ -5,8 +7,6 @@ namespace PublishingPlatform.SDK.Clients.BookDistribution.Requests;
 /// </summary>
 internal sealed class DefaultBookDistributionRequestHeadersFactory : IBookDistributionRequestHeadersFactory
 {
-    private const string IdempotencyHeaderName = "Idempotency-Key";
-
     /// <inheritdoc />
     public IReadOnlyDictionary<string, string>? CreateIdempotencyHeaders(string? idempotencyKey)
     {
@@ -17,7 +17,7 @@ internal sealed class DefaultBookDistributionRequestHeadersFactory : IBookDistri
 
         return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            [IdempotencyHeaderName] = idempotencyKey,
+            [TransportHeaderNames.IdempotencyKey] = idempotencyKey,
         };
     }
 }

--- a/src/PublishingPlatform.SDK/Clients/BookPublishing/Requests/DefaultBookPublishingRequestHeadersFactory.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookPublishing/Requests/DefaultBookPublishingRequestHeadersFactory.cs
@@ -1,3 +1,5 @@
+using PublishingPlatform.SDK.Infrastructure.Transport;
+
 namespace PublishingPlatform.SDK.Clients.BookPublishing.Requests;
 
 /// <summary>
@@ -15,7 +17,7 @@ internal sealed class DefaultBookPublishingRequestHeadersFactory : IBookPublishi
 
         return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            ["Idempotency-Key"] = idempotencyKey,
+            [TransportHeaderNames.IdempotencyKey] = idempotencyKey,
         };
     }
 }

--- a/src/PublishingPlatform.SDK/Clients/Books/Requests/DefaultBookRequestHeadersFactory.cs
+++ b/src/PublishingPlatform.SDK/Clients/Books/Requests/DefaultBookRequestHeadersFactory.cs
@@ -1,3 +1,5 @@
+using PublishingPlatform.SDK.Infrastructure.Transport;
+
 namespace PublishingPlatform.SDK.Clients.Books.Requests;
 
 internal sealed class DefaultBookRequestHeadersFactory : IBookRequestHeadersFactory
@@ -11,7 +13,7 @@ internal sealed class DefaultBookRequestHeadersFactory : IBookRequestHeadersFact
 
         return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            ["Idempotency-Key"] = idempotencyKey,
+            [TransportHeaderNames.IdempotencyKey] = idempotencyKey,
         };
     }
 

--- a/src/PublishingPlatform.SDK/Clients/Webhooks/Requests/DefaultWebhookRequestHeadersFactory.cs
+++ b/src/PublishingPlatform.SDK/Clients/Webhooks/Requests/DefaultWebhookRequestHeadersFactory.cs
@@ -1,3 +1,5 @@
+using PublishingPlatform.SDK.Infrastructure.Transport;
+
 namespace PublishingPlatform.SDK.Clients.Webhooks.Requests;
 
 /// <summary>
@@ -5,8 +7,6 @@ namespace PublishingPlatform.SDK.Clients.Webhooks.Requests;
 /// </summary>
 internal sealed class DefaultWebhookRequestHeadersFactory : IWebhookRequestHeadersFactory
 {
-    private const string IdempotencyHeaderName = "Idempotency-Key";
-
     /// <inheritdoc />
     public IReadOnlyDictionary<string, string>? CreateIdempotencyHeaders(string? idempotencyKey)
     {
@@ -17,7 +17,7 @@ internal sealed class DefaultWebhookRequestHeadersFactory : IWebhookRequestHeade
 
         return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            [IdempotencyHeaderName] = idempotencyKey,
+            [TransportHeaderNames.IdempotencyKey] = idempotencyKey,
         };
     }
 }

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransport.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransport.cs
@@ -125,6 +125,8 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
             : moduleName;
         var options = _diagnosticsOptionsResolver.Resolve(effectiveModuleName);
         var correlationId = ResolveCorrelationId(headers, options);
+        var hasIdempotencyKey = HasHeader(headers, TransportHeaderNames.IdempotencyKey);
+        var canReplayContent = IsReplayableContent(content);
         var diagnosticsContext = new RequestDiagnosticsContext(
             effectiveModuleName,
             effectiveOperationName,
@@ -145,6 +147,8 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
                 new PublishingPlatformResilienceContext
                 {
                     Method = method,
+                    HasIdempotencyKey = hasIdempotencyKey,
+                    CanReplayContent = canReplayContent,
                 },
                 async ct =>
                 {
@@ -216,6 +220,35 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
     {
         var separatorIndex = operationName.IndexOf('.', StringComparison.Ordinal);
         return separatorIndex <= 0 ? "SDK" : operationName[..separatorIndex];
+    }
+
+    private static bool HasHeader(IReadOnlyDictionary<string, string>? headers, string headerName)
+    {
+        if (headers is null)
+        {
+            return false;
+        }
+
+        foreach (var header in headers)
+        {
+            if (string.Equals(header.Key, headerName, StringComparison.OrdinalIgnoreCase)
+                && !string.IsNullOrWhiteSpace(header.Value))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsReplayableContent(HttpContent? content)
+    {
+        if (content is null)
+        {
+            return true;
+        }
+
+        return content is not StreamContent and not MultipartFormDataContent;
     }
 
     private static Activity? StartActivity(RequestDiagnosticsContext context)

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/TransportHeaderNames.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/TransportHeaderNames.cs
@@ -14,4 +14,9 @@ internal static class TransportHeaderNames
     /// Correlation header used to propagate request tracing context.
     /// </summary>
     internal const string CorrelationId = "X-Correlation-Id";
+
+    /// <summary>
+    /// Idempotency header used for retry-safe mutating operations.
+    /// </summary>
+    internal const string IdempotencyKey = "Idempotency-Key";
 }

--- a/src/PublishingPlatform.SDK/Internal/Resilience/DefaultPublishingPlatformResiliencePipeline.cs
+++ b/src/PublishingPlatform.SDK/Internal/Resilience/DefaultPublishingPlatformResiliencePipeline.cs
@@ -7,6 +7,8 @@ internal sealed class DefaultPublishingPlatformResiliencePipeline : IPublishingP
 {
     private readonly ResiliencePipeline<HttpResponseMessage> _pipeline;
     private static readonly ResiliencePropertyKey<HttpMethod> HttpMethodKey = new("PublishingPlatform.HttpMethod");
+    private static readonly ResiliencePropertyKey<bool> HasIdempotencyKey = new("PublishingPlatform.HasIdempotencyKey");
+    private static readonly ResiliencePropertyKey<bool> CanReplayContent = new("PublishingPlatform.CanReplayContent");
 
     internal DefaultPublishingPlatformResiliencePipeline(ResiliencePipeline<HttpResponseMessage> pipeline)
     {
@@ -23,6 +25,8 @@ internal sealed class DefaultPublishingPlatformResiliencePipeline : IPublishingP
 
         var resilienceContext = ResilienceContextPool.Shared.Get(cancellationToken);
         resilienceContext.Properties.Set(HttpMethodKey, context.Method);
+        resilienceContext.Properties.Set(HasIdempotencyKey, context.HasIdempotencyKey);
+        resilienceContext.Properties.Set(CanReplayContent, context.CanReplayContent);
 
         try
         {
@@ -45,6 +49,30 @@ internal sealed class DefaultPublishingPlatformResiliencePipeline : IPublishingP
         }
 
         method = HttpMethod.Get;
+        return false;
+    }
+
+    internal static bool TryGetHasIdempotencyKey(ResilienceContext context, out bool hasIdempotencyKey)
+    {
+        if (context.Properties.TryGetValue(HasIdempotencyKey, out var value))
+        {
+            hasIdempotencyKey = value;
+            return true;
+        }
+
+        hasIdempotencyKey = false;
+        return false;
+    }
+
+    internal static bool TryGetCanReplayContent(ResilienceContext context, out bool canReplayContent)
+    {
+        if (context.Properties.TryGetValue(CanReplayContent, out var value))
+        {
+            canReplayContent = value;
+            return true;
+        }
+
+        canReplayContent = true;
         return false;
     }
 }

--- a/src/PublishingPlatform.SDK/Internal/Resilience/ResiliencePipelineFactory.cs
+++ b/src/PublishingPlatform.SDK/Internal/Resilience/ResiliencePipelineFactory.cs
@@ -35,7 +35,7 @@ internal static class ResiliencePipelineFactory
                 MaxRetryAttempts = options.Retry.MaxRetryAttempts,
                 Delay = options.Retry.BaseDelay,
                 BackoffType = DelayBackoffType.Exponential,
-                UseJitter = true,
+                UseJitter = options.Retry.UseJitter,
                 ShouldHandle = args => new ValueTask<bool>(ShouldRetry(args, options.Retry.RetryNonIdempotentMethods)),
             });
         }
@@ -79,7 +79,7 @@ internal static class ResiliencePipelineFactory
             return false;
         }
 
-        if (!IsMethodAllowed(method, retryNonIdempotentMethods))
+        if (!IsMethodAllowed(method, retryNonIdempotentMethods, args.Context))
         {
             return false;
         }
@@ -94,17 +94,27 @@ internal static class ResiliencePipelineFactory
             return false;
         }
 
-        return IsMethodAllowed(method, retryNonIdempotentMethods);
+        return IsMethodAllowed(method, retryNonIdempotentMethods, context);
     }
 
     private static bool IsMethodAllowed(HttpMethod method, bool retryNonIdempotentMethods)
+    {
+        return IsMethodAllowed(method, retryNonIdempotentMethods, context: null);
+    }
+
+    private static bool IsMethodAllowed(HttpMethod method, bool retryNonIdempotentMethods, ResilienceContext? context)
     {
         if (IsIdempotentMethod(method))
         {
             return true;
         }
 
-        return retryNonIdempotentMethods && IsNonIdempotentRetryCandidate(method);
+        if (!retryNonIdempotentMethods || !IsNonIdempotentRetryCandidate(method))
+        {
+            return false;
+        }
+
+        return context is not null && IsNonIdempotentRetrySafe(context);
     }
 
     private static bool IsIdempotentMethod(HttpMethod method)
@@ -133,6 +143,22 @@ internal static class ResiliencePipelineFactory
             or HttpStatusCode.BadGateway
             or HttpStatusCode.ServiceUnavailable
             or HttpStatusCode.GatewayTimeout;
+    }
+
+    private static bool IsNonIdempotentRetrySafe(ResilienceContext context)
+    {
+        if (!DefaultPublishingPlatformResiliencePipeline.TryGetHasIdempotencyKey(context, out var hasIdempotencyKey)
+            || !hasIdempotencyKey)
+        {
+            return false;
+        }
+
+        if (!DefaultPublishingPlatformResiliencePipeline.TryGetCanReplayContent(context, out var canReplayContent))
+        {
+            return true;
+        }
+
+        return canReplayContent;
     }
 
     private static void Validate(PublishingPlatformResilienceOptions options)

--- a/src/PublishingPlatform.SDK/Options/RetryResilienceOptions.cs
+++ b/src/PublishingPlatform.SDK/Options/RetryResilienceOptions.cs
@@ -1,12 +1,32 @@
 namespace PublishingPlatform.SDK.Options;
 
+/// <summary>
+/// Configures retry strategy behavior for SDK transport resilience.
+/// </summary>
 public sealed class RetryResilienceOptions
 {
+    /// <summary>
+    /// Gets or sets whether retry strategy is enabled.
+    /// </summary>
     public bool Enabled { get; set; }
 
+    /// <summary>
+    /// Gets or sets maximum retry attempts after the initial request.
+    /// </summary>
     public int MaxRetryAttempts { get; set; } = 3;
 
+    /// <summary>
+    /// Gets or sets base delay used by retry backoff.
+    /// </summary>
     public TimeSpan BaseDelay { get; set; } = TimeSpan.FromMilliseconds(500);
 
+    /// <summary>
+    /// Gets or sets whether non-idempotent methods can be retried when retry-safety requirements are satisfied.
+    /// </summary>
     public bool RetryNonIdempotentMethods { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether randomized jitter is applied to retry delays.
+    /// </summary>
+    public bool UseJitter { get; set; } = true;
 }

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/ResilienceAndTransportTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/ResilienceAndTransportTests.cs
@@ -406,6 +406,39 @@ public sealed class ResilienceAndTransportTests
         capturedToken.Should().Be(tokenSource.Token);
         capturedContext.Should().NotBeNull();
         capturedContext!.Method.Should().Be(HttpMethod.Get);
+        capturedContext.HasIdempotencyKey.Should().BeFalse();
+        capturedContext.CanReplayContent.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SendAsync_SetsRetrySafetyContext_ForIdempotencyHeaderAndNonReplayableContent()
+    {
+        PublishingPlatformResilienceContext? capturedContext = null;
+        var pipeline = Substitute.For<IPublishingPlatformResiliencePipeline>();
+        pipeline.ExecuteAsync(Arg.Any<PublishingPlatformResilienceContext>(), Arg.Any<Func<CancellationToken, Task<HttpResponseMessage>>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                capturedContext = callInfo.Arg<PublishingPlatformResilienceContext>();
+                var operation = callInfo.Arg<Func<CancellationToken, Task<HttpResponseMessage>>>();
+                return operation(callInfo.Arg<CancellationToken>());
+            });
+
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.test") };
+        var transport = new SharedHttpTransport(httpClient, pipeline, new FixedCorrelationIdProvider("corr"), new DefaultPublishingPlatformErrorMapper());
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [TransportHeaderNames.IdempotencyKey] = "idem-1",
+        };
+        await using var stream = new MemoryStream([1, 2, 3]);
+        using var content = new StreamContent(stream);
+
+        await transport.SendAsync(HttpMethod.Post, "/books", content, headers, "Books.Create", CancellationToken.None, "Books");
+
+        capturedContext.Should().NotBeNull();
+        capturedContext!.Method.Should().Be(HttpMethod.Post);
+        capturedContext.HasIdempotencyKey.Should().BeTrue();
+        capturedContext.CanReplayContent.Should().BeFalse();
     }
 
     [Fact]
@@ -738,7 +771,12 @@ public sealed class ResilienceAndTransportTests
         var attempts = 0;
 
         var response = await pipeline.ExecuteAsync(
-            new PublishingPlatformResilienceContext { Method = HttpMethod.Post },
+            new PublishingPlatformResilienceContext
+            {
+                Method = HttpMethod.Post,
+                HasIdempotencyKey = true,
+                CanReplayContent = true,
+            },
             _ =>
             {
                 attempts++;
@@ -798,7 +836,12 @@ public sealed class ResilienceAndTransportTests
         var attempts = 0;
 
         var response = await pipeline.ExecuteAsync(
-            new PublishingPlatformResilienceContext { Method = HttpMethod.Post },
+            new PublishingPlatformResilienceContext
+            {
+                Method = HttpMethod.Post,
+                HasIdempotencyKey = true,
+                CanReplayContent = true,
+            },
             _ =>
             {
                 attempts++;
@@ -807,6 +850,107 @@ public sealed class ResilienceAndTransportTests
 
         response.StatusCode.Should().Be(HttpStatusCode.BadGateway);
         attempts.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CreatePipeline_DoesNotRetryTransientStatusCodes_ForPostWithoutIdempotencyKey()
+    {
+        var options = new PublishingPlatformResilienceOptions
+        {
+            Enabled = true,
+            Retry = new RetryResilienceOptions
+            {
+                Enabled = true,
+                RetryNonIdempotentMethods = true,
+                MaxRetryAttempts = 2,
+                BaseDelay = TimeSpan.FromMilliseconds(1),
+            },
+        };
+
+        var pipeline = ResiliencePipelineFactory.Create(options);
+        var attempts = 0;
+
+        var response = await pipeline.ExecuteAsync(
+            new PublishingPlatformResilienceContext
+            {
+                Method = HttpMethod.Post,
+                HasIdempotencyKey = false,
+                CanReplayContent = true,
+            },
+            _ =>
+            {
+                attempts++;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        attempts.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CreatePipeline_DoesNotRetryTransientStatusCodes_ForPostWithNonReplayableContent()
+    {
+        var options = new PublishingPlatformResilienceOptions
+        {
+            Enabled = true,
+            Retry = new RetryResilienceOptions
+            {
+                Enabled = true,
+                RetryNonIdempotentMethods = true,
+                MaxRetryAttempts = 2,
+                BaseDelay = TimeSpan.FromMilliseconds(1),
+            },
+        };
+
+        var pipeline = ResiliencePipelineFactory.Create(options);
+        var attempts = 0;
+
+        var response = await pipeline.ExecuteAsync(
+            new PublishingPlatformResilienceContext
+            {
+                Method = HttpMethod.Post,
+                HasIdempotencyKey = true,
+                CanReplayContent = false,
+            },
+            _ =>
+            {
+                attempts++;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        attempts.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CreatePipeline_AcceptsRetryConfiguration_WithJitterDisabled()
+    {
+        var options = new PublishingPlatformResilienceOptions
+        {
+            Enabled = true,
+            Retry = new RetryResilienceOptions
+            {
+                Enabled = true,
+                UseJitter = false,
+                MaxRetryAttempts = 2,
+                BaseDelay = TimeSpan.FromMilliseconds(1),
+            },
+        };
+
+        var pipeline = ResiliencePipelineFactory.Create(options);
+        var attempts = 0;
+
+        var response = await pipeline.ExecuteAsync(
+            new PublishingPlatformResilienceContext { Method = HttpMethod.Get },
+            _ =>
+            {
+                attempts++;
+                return Task.FromResult(new HttpResponseMessage(
+                    attempts < 3 ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.OK));
+            });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        attempts.Should().Be(3);
     }
 
     [Fact]


### PR DESCRIPTION
# Summary

Harden retry/backoff behavior for transient scenarios by enforcing idempotency safety for non-idempotent operations while keeping resilience opt-in.

What changed:
- Added `RetryResilienceOptions.UseJitter` (default `true`) for configurable jitter behavior and deterministic test scenarios.
- Extended resilience context with retry-safety metadata (`HasIdempotencyKey`, `CanReplayContent`).
- Updated retry predicate rules so `POST`/`PATCH` retries require all of:
  - `RetryNonIdempotentMethods = true`
  - idempotency key present
  - replay-safe request content
- Kept idempotent retry behavior unchanged (`429`, `502`, `503`, `504`).
- Kept non-idempotent transient set conservative (`429`, `503`).
- Centralized header constant usage for `Idempotency-Key` in transport/header factories.
- Updated docs and retry example to reflect jitter config and non-idempotent retry safety requirements.

API impact:
- Additive options/context changes only; existing client operation signatures and contracts remain compatible.

# Validation

- [x] `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal`
- [x] Additional checks relevant to this PR:
  - Added resilience tests for idempotency-key gating, replayability gating, jitter-off configuration, and retry safety context propagation.

Test result evidence:
- Full suite: 247 passed, 0 failed, 0 skipped.

# Release Please Override (Required for releasable changes)

```text
BEGIN_COMMIT_OVERRIDE
feat(resilience): harden transient retry safety for non-idempotent operations
END_COMMIT_OVERRIDE
```

# Manual NuGet Publish

1. Confirm `Directory.Build.props` version equals intended release version.
2. Create matching tag `v<version>` on that exact commit.
3. Run `Publish NuGet` workflow manually with that tag.
4. Verify package version appears on NuGet.
