### PR TITLE
RPS-30 feat!: add explicit tradeoffs + openapi/docs/test alignment for issue #30

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.2.2</Version>
+    <Version>1.0.0</Version>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Runnable scripts are available in:
 
 - `examples/BasicUsage/BuilderInitializationExample.csx`
 - `examples/BasicUsage/DiInitializationExample.csx`
+- `examples/ArchitectureTradeoffs/ArchitectureTradeoffsExample.csx`
 - `examples/Diagnostics/README.md`
 - `examples/BookPublishing/BookPublishingExample.csx`
 - `examples/BookDistribution/BookDistributionExample.csx`
@@ -308,6 +309,20 @@ Correlation model:
 This separation improves observability, retry safety, and failure isolation for partner/channel sync workflows.
 
 Status values returned by publishing and distribution responses are exposed as strings instead of enums. Backend status sets can grow independently of SDK releases, and strings preserve new or channel-specific values without deserialization failures. Consumers should compare known status values case-insensitively and handle unknown values as valid future API responses.
+
+## Architecture tradeoffs
+
+The SDK deliberately chooses depth over breadth. The current surface goes deep on book lifecycle workflows: catalog metadata, content, publishing, distribution, access, analytics, audit logs, and webhooks. Broader publishing domains should be added only when they support that lifecycle instead of turning the SDK into a shallow generic wrapper.
+
+All modules use a central internal transport. This trades away per-client HTTP pipeline customization so correlation IDs, HTTPS enforcement, resilience, diagnostics, authentication, and error normalization stay consistent. Module clients remain responsible for orchestration, validation, endpoint shape, and response mapping.
+
+Public models are strict, platform-owned SDK contracts. Provider-specific payloads, including Google Books-derived wire shapes, stay internal. Some backend-grown value sets, such as publishing and distribution status strings, intentionally remain strings so new server values do not break older consumers.
+
+Retry defaults are conservative. Retries are opt-in, idempotent methods are the default safe retry target, and non-idempotent `POST` or `PATCH` retries require explicit configuration plus an `Idempotency-Key` when replay is possible. Mutating examples use idempotency keys because duplicate publishing, distribution, or webhook operations are worse than a visible transient failure.
+
+Diagnostics are privacy-preserving by default. Logging, tracing, and metrics are opt-in, and request bodies, response bodies, API keys, authorization headers, idempotency keys, download URLs, uploaded content, and user/customer identifiers are excluded unless a future explicit option states otherwise.
+
+Errors are normalized at the transport boundary before exception mapping. The default mapper returns structured SDK exceptions with status, error code, request ID, correlation ID, operation name, method, path, and message. Consumers can replace the mapper while keeping the same normalized error context.
 
 ### Side-by-side API usage
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -123,3 +123,29 @@ Future remote upload behavior can build on this local storage result, but it sho
 The SDK follows a Depth over Breadth strategy. The priority is to make the book lifecycle reliable and ergonomic before expanding into unrelated publishing domains.
 
 This means new modules should be added only when they support the core book lifecycle or a clear extension of it.
+
+## Explicit Tradeoffs
+
+### Depth Over Breadth
+
+The SDK prioritizes a complete book-lifecycle experience over a broad publishing API wrapper. Catalog metadata, content, publishing, distribution, access, analytics, audit logs, and webhooks form one coherent operational path. New domains should prove they support that path before becoming public modules.
+
+### Central Transport Over Per-Client Flexibility
+
+Every module uses the shared transport so HTTPS enforcement, authentication, correlation IDs, resilience, diagnostics, and error normalization behave the same way. This reduces per-client customization, but it keeps partner integrations predictable and prevents module-level drift.
+
+### Typed Model Strictness
+
+Public contracts are platform-owned SDK models rather than provider wire models. Request models validate obvious consumer mistakes before transport. Response models stay typed where the platform contract is stable, while server-grown values such as publishing and distribution statuses remain strings for forward compatibility.
+
+### Retry Defaults And Idempotency
+
+Retry behavior is disabled until consumers opt in. When enabled, idempotent methods are retried conservatively for transient failures. Non-idempotent methods require explicit opt-in and replay-safe request conditions, including an `Idempotency-Key` where the operation supports one.
+
+### Diagnostics Privacy Defaults
+
+Diagnostics are opt-in and privacy-preserving. Correlation IDs are safe to propagate, but API keys, authorization headers, idempotency keys, request and response bodies, uploaded book content, download URLs, and user/customer identifiers must stay out of default logs and traces.
+
+### Error Normalization
+
+The transport normalizes unsuccessful responses into a shared error context before the configured mapper creates exceptions. This keeps the public exception model consistent while allowing consumers to plug in domain-specific exception mapping.

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -10,6 +10,8 @@ The SDK focuses on the book lifecycle before expanding into broader publishing d
 
 This keeps the SDK useful for real partner workflows instead of spreading effort across shallow generic API wrappers.
 
+Tradeoff: the SDK intentionally delays adjacent publishing capabilities until the book workflow is reliable end to end.
+
 ## REST-Only SDK Surface
 
 Status: Accepted.
@@ -25,6 +27,8 @@ Status: Accepted.
 All module clients should use the shared internal HTTP transport. This trades some per-client flexibility for consistency.
 
 The benefit is a single place for correlation IDs, JSON request conventions, resilience, and error normalization. Module clients should focus on request validation, endpoint shape, and response mapping.
+
+Tradeoff: consumers get fewer module-specific HTTP customization seams, but every module observes the same security, diagnostics, retry, and error rules.
 
 ## Publishing Lifecycle And Distribution Workflow Separation
 
@@ -57,6 +61,8 @@ Resilience is disabled by default. Consumers must explicitly enable retry, circu
 
 Retries must remain conservative because some operations can have side effects. Future unsafe operations should require idempotency-aware design before they are retried automatically.
 
+Tradeoff: default behavior may surface transient failures instead of hiding them, but it avoids duplicate side effects for publishing, distribution, webhook, and content operations.
+
 ## Central Error Mapping
 
 Status: Accepted.
@@ -64,6 +70,8 @@ Status: Accepted.
 The SDK uses `IPublishingPlatformErrorMapper` as the single extension point for API error conversion.
 
 The default mapper returns `ApiException` for generic API failures and typed book exceptions for common book-centric HTTP failures. Consumers can replace it when they need domain-specific exceptions, but the transport should still provide the same normalized context.
+
+Tradeoff: errors are normalized before module-specific interpretation, which keeps behavior consistent while requiring mapper customization for highly specialized consumer exceptions.
 
 ## Provider-Hidden Query Architecture
 
@@ -104,6 +112,8 @@ Diagnostics should be safe by default. Correlation IDs and Activity-based tracin
 
 Diagnostics work is still evolving, so docs and implementation should avoid promising full logging, metrics, or per-module override behavior until those tickets are complete.
 
+Tradeoff: default diagnostics favor privacy over complete payload visibility. Consumers should use backend logs or explicit future diagnostics options for deeper inspection.
+
 ## Strong Typing And Manual Mapping
 
 Status: Accepted direction.
@@ -111,3 +121,5 @@ Status: Accepted direction.
 Public SDK models should be strongly typed and platform-owned. Mapping should stay explicit and manual through focused code, not AutoMapper or hidden reflection-based mapping.
 
 This keeps the public contract stable and makes future provider integrations, including query sources, easier to isolate.
+
+Tradeoff: strict SDK-owned models require deliberate schema updates, while selected string fields preserve compatibility with backend-owned value sets that can grow independently.

--- a/docs/openapi-google-books-derived-sdk-contract.yaml
+++ b/docs/openapi-google-books-derived-sdk-contract.yaml
@@ -5,6 +5,20 @@ info:
   description: |
     Implemented API contract aligned to the current SDK implementation
     on local branch feature/RPS-19.
+
+    Architecture contract notes:
+    - The SDK intentionally models deep book-lifecycle workflows before broader publishing domains.
+    - Module clients share one transport contract for correlation, resilience, diagnostics, and normalized errors.
+    - Public schemas are strict, platform-owned SDK models; provider-specific payloads stay internal.
+    - Non-idempotent retries require explicit opt-in and an idempotency key when replay is possible.
+    - Diagnostics default to privacy-preserving behavior and omit sensitive headers, payloads, and content.
+x-sdk-architecture-tradeoffs:
+  depthOverBreadth: Book lifecycle depth is prioritized over broad generic publishing coverage.
+  centralTransport: Shared transport consistency is favored over per-client HTTP pipeline variation.
+  typedModelStrictness: SDK-owned models are strict at the public boundary while status strings remain forward-compatible.
+  retryAndIdempotency: Retry defaults protect side-effecting operations unless idempotency is explicit.
+  diagnosticsPrivacy: Diagnostics are opt-in and redact sensitive request, response, and content data by default.
+  errorNormalization: API errors are normalized once at transport level before mapper-specific exceptions are produced.
 servers:
   - url: https://api.publisher-platform.dev
 security:

--- a/examples/ArchitectureTradeoffs/ArchitectureTradeoffsExample.csx
+++ b/examples/ArchitectureTradeoffs/ArchitectureTradeoffsExample.csx
@@ -1,0 +1,50 @@
+//r "nuget: PublishingPlatform.SDK"
+
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Infrastructure.Diagnostics;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Options;
+
+var client = PublishingPlatformClientBuilder.Create(new PublishingPlatformClientOptions
+{
+    BaseUrl = "https://api.books.example",
+    ApiKey = Environment.GetEnvironmentVariable("PUBLISHING_PLATFORM_API_KEY") ?? string.Empty,
+    Diagnostics = new DiagnosticsOptions
+    {
+        EnableTracing = true,
+        EnableMetrics = true,
+        EnableLogging = false
+    },
+    Resilience = new PublishingPlatformResilienceOptions
+    {
+        Enabled = true,
+        Retry = new RetryResilienceOptions
+        {
+            Enabled = true,
+            MaxRetryAttempts = 3,
+            BaseDelay = TimeSpan.FromMilliseconds(200),
+            RetryNonIdempotentMethods = false,
+            UseJitter = true
+        }
+    }
+}).Build();
+
+var book = await client.Books.GetByIdAsync("book-123");
+Console.WriteLine($"Loaded book: {book.Title}");
+
+var publishStatus = await client.BookPublishing.PublishAsync(
+    book.Id,
+    new PublishBookRequest { Notes = "Release approved by editorial workflow." },
+    idempotencyKey: $"publish-{book.Id}-2026-05");
+
+Console.WriteLine($"Publishing status: {publishStatus.Status}");
+
+var distribution = await client.BookDistribution.StartAsync(
+    book.Id,
+    new StartBookDistributionRequest
+    {
+        Channels = ["mobile", "partner-store"],
+    },
+    idempotencyKey: $"distribution-{book.Id}-2026-05");
+
+Console.WriteLine($"Distribution operation: {distribution.OperationId}");

--- a/examples/ArchitectureTradeoffs/README.md
+++ b/examples/ArchitectureTradeoffs/README.md
@@ -1,0 +1,11 @@
+# Architecture Tradeoffs Example
+
+This example shows the consumer-facing choices behind the book-centric SDK architecture:
+
+- one root client with book lifecycle modules
+- shared transport behavior for correlation, diagnostics, resilience, and errors
+- conservative retry defaults for side-effecting requests
+- explicit idempotency keys for replay-safe publishing and distribution operations
+- privacy-preserving diagnostics that stay opt-in
+
+Run `ArchitectureTradeoffsExample.csx` after setting a valid API base URL and API key.

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/DocumentationTradeoffsContractTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/DocumentationTradeoffsContractTests.cs
@@ -1,0 +1,99 @@
+namespace PublishingPlatform.SDK.Tests.Infrastructure;
+
+public sealed class DocumentationTradeoffsContractTests
+{
+    private static readonly string[] RequiredTradeoffPhrases =
+    {
+        "depth over breadth",
+        "central internal transport",
+        "public models are strict",
+        "retry defaults are conservative",
+        "diagnostics are privacy-preserving",
+        "errors are normalized",
+    };
+
+    private static readonly string[] RequiredOpenApiTradeoffKeys =
+    {
+        "depthOverBreadth",
+        "centralTransport",
+        "typedModelStrictness",
+        "retryAndIdempotency",
+        "diagnosticsPrivacy",
+        "errorNormalization",
+    };
+
+    [Fact]
+    public void Readme_IncludesRequiredArchitectureTradeoffs()
+    {
+        var readme = ReadRepositoryFile("README.md");
+        var normalizedReadme = readme.ToLowerInvariant();
+
+        readme.Should().Contain("## Architecture tradeoffs");
+
+        foreach (var phrase in RequiredTradeoffPhrases)
+        {
+            normalizedReadme.Should().Contain(phrase);
+        }
+    }
+
+    [Fact]
+    public void ArchitectureDocs_IncludeRequiredTradeoffSections()
+    {
+        var architecture = ReadRepositoryFile(@"docs\architecture.md");
+
+        foreach (var heading in new[]
+        {
+            "### Depth Over Breadth",
+            "### Central Transport Over Per-Client Flexibility",
+            "### Typed Model Strictness",
+            "### Retry Defaults And Idempotency",
+            "### Diagnostics Privacy Defaults",
+            "### Error Normalization",
+        })
+        {
+            architecture.Should().Contain(heading);
+        }
+    }
+
+    [Fact]
+    public void OpenApiSpec_DeclaresSdkArchitectureTradeoffExtension()
+    {
+        var spec = ReadRepositoryFile(@"docs\openapi-google-books-derived-sdk-contract.yaml");
+
+        spec.Should().Contain("x-sdk-architecture-tradeoffs:");
+
+        foreach (var key in RequiredOpenApiTradeoffKeys)
+        {
+            spec.Should().Contain($"{key}:");
+        }
+    }
+
+    [Fact]
+    public void ArchitectureTradeoffsExample_IsLinkedFromReadme()
+    {
+        var readme = ReadRepositoryFile("README.md");
+        var example = ReadRepositoryFile(@"examples\ArchitectureTradeoffs\ArchitectureTradeoffsExample.csx");
+
+        readme.Should().Contain("examples/ArchitectureTradeoffs/ArchitectureTradeoffsExample.csx");
+        example.Should().Contain("RetryNonIdempotentMethods = false");
+        example.Should().Contain("idempotencyKey:");
+        example.Should().Contain("EnableLogging = false");
+    }
+
+    private static string ReadRepositoryFile(string relativePath)
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            var candidate = Path.Combine(current.FullName, relativePath);
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate);
+            }
+
+            current = current.Parent;
+        }
+
+        throw new FileNotFoundException($"Could not locate repository file '{relativePath}'.");
+    }
+}

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/OpenApiSpecificationContractsTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/OpenApiSpecificationContractsTests.cs
@@ -10,7 +10,7 @@ namespace PublishingPlatform.SDK.Tests.Infrastructure;
 public sealed class OpenApiSpecificationContractsTests
 {
     private const string SpecRelativePath = @"docs\openapi-google-books-derived-sdk-contract.yaml";
-    private const string ExpectedSha256 = "36ebfa91e7e053bb3f22be4dea7414c3dd031c1f8f4d38560429be4529865d4e";
+    private const string ExpectedSha256 = "81c41df3c02ffd3446005aa26af096e130d3b52611f037391f099e3675eb1808";
 
     private static readonly string[] ExpectedOperations =
     {


### PR DESCRIPTION
# Docs and Contract Alignment (Issue #30)

- Added explicit architecture tradeoffs to README and docs:
  - depth over breadth
  - shared transport consistency
  - typed model boundaries
  - retry/idempotency behavior
  - diagnostics privacy defaults
  - error normalization
- Updated OpenAPI spec with architecture tradeoff metadata and notes.
- Added an architecture tradeoffs example under `examples/ArchitectureTradeoffs`.
- Added tests to guard documentation and OpenAPI tradeoff coverage.
- Updated OpenAPI spec hash baseline test to match intentional spec changes.
