### PR TITLE
RPS-106 feat: add resumable upload session and chunk workflow

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Runnable scripts are available in:
 - `examples/Pagination/PaginationExample.csx`
 - `examples/MockApiCoreFlowExample.csx`
 - `examples/MockPublishingPlatform.Api/README.md`
+- `examples/ResumableUpload/ResumableUploadExample.csx`
 
 ## Client modules: available properties and use cases
 
@@ -152,11 +153,16 @@ Available operations:
 
 - `GetAsync(...)`: retrieve content metadata for a book.
 - `UploadOrReplaceAsync(...)`: upload or replace book content and return the updated content metadata.
+- `StartResumableUploadAsync(...)`: create a resumable upload session.
+- `UploadChunkAsync(...)`: upload one chunk to an existing session.
+- `GetUploadSessionAsync(...)`: query resumable upload progress/state.
+- `CompleteResumableUploadAsync(...)`: finalize a resumable upload and materialize content metadata.
 
 Typical use cases:
 
 - Uploading source content for books.
 - Replacing or versioning stored content artifacts.
+- Resuming interrupted large uploads by session and byte range.
 
 ### `BookPublishing` (`IBookPublishingClient`)
 

--- a/docs/openapi-google-books-derived-sdk-contract.yaml
+++ b/docs/openapi-google-books-derived-sdk-contract.yaml
@@ -233,6 +233,102 @@ paths:
         default:
           $ref: '#/components/responses/ErrorResponse'
 
+  /books/{bookId}/content/uploads:
+    post:
+      tags: [BookContent]
+      operationId: bookContent_startResumableUpload
+      summary: Start a resumable upload session
+      parameters:
+        - $ref: '#/components/parameters/CorrelationId'
+        - $ref: '#/components/parameters/BookId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StartResumableUploadRequest'
+      responses:
+        '200':
+          description: Upload session created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UploadSessionInfo'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+
+  /books/{bookId}/content/uploads/{uploadSessionId}:
+    get:
+      tags: [BookContent]
+      operationId: bookContent_getUploadSession
+      summary: Get resumable upload session state
+      parameters:
+        - $ref: '#/components/parameters/CorrelationId'
+        - $ref: '#/components/parameters/BookId'
+        - $ref: '#/components/parameters/UploadSessionId'
+      responses:
+        '200':
+          description: Upload session state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UploadSessionInfo'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+
+  /books/{bookId}/content/uploads/{uploadSessionId}/chunks:
+    put:
+      tags: [BookContent]
+      operationId: bookContent_uploadChunk
+      summary: Upload one resumable chunk
+      parameters:
+        - $ref: '#/components/parameters/CorrelationId'
+        - $ref: '#/components/parameters/BookId'
+        - $ref: '#/components/parameters/UploadSessionId'
+        - $ref: '#/components/parameters/ContentRange'
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              $ref: '#/components/schemas/UploadChunkRequest'
+      responses:
+        '200':
+          description: Chunk accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UploadChunkResult'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+
+  /books/{bookId}/content/uploads/{uploadSessionId}/complete:
+    post:
+      tags: [BookContent]
+      operationId: bookContent_completeResumableUpload
+      summary: Complete resumable upload session
+      parameters:
+        - $ref: '#/components/parameters/CorrelationId'
+        - $ref: '#/components/parameters/BookId'
+        - $ref: '#/components/parameters/UploadSessionId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CompleteResumableUploadRequest'
+      responses:
+        '200':
+          description: Finalized book content metadata
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookContent'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+
   /books/{bookId}/publishing/publish:
     post:
       tags: [BookPublishing]
@@ -728,6 +824,13 @@ components:
       schema:
         type: string
         minLength: 1
+    UploadSessionId:
+      in: path
+      name: uploadSessionId
+      required: true
+      schema:
+        type: string
+        minLength: 1
     CorrelationId:
       in: header
       name: X-Correlation-Id
@@ -746,6 +849,13 @@ components:
       in: header
       name: If-Match
       required: false
+      schema:
+        type: string
+        minLength: 1
+    ContentRange:
+      in: header
+      name: Content-Range
+      required: true
       schema:
         type: string
         minLength: 1
@@ -914,6 +1024,93 @@ components:
           enum: [pdf, epub]
         idempotencyKey:
           type: [string, "null"]
+
+    StartResumableUploadRequest:
+      type: object
+      required: [fileName, totalBytes]
+      properties:
+        fileName:
+          type: string
+          minLength: 1
+        contentType:
+          type: [string, "null"]
+        format:
+          type: [string, "null"]
+          enum: [pdf, epub, null]
+        totalBytes:
+          type: integer
+          format: int64
+          minimum: 1
+        idempotencyKey:
+          type: [string, "null"]
+
+    CompleteResumableUploadRequest:
+      type: object
+      properties:
+        finalChecksum:
+          type: [string, "null"]
+        idempotencyKey:
+          type: [string, "null"]
+
+    UploadChunkRequest:
+      type: object
+      required: [chunk, chunkStart, chunkEnd, totalBytes]
+      properties:
+        chunk:
+          type: string
+          format: binary
+        chunkStart:
+          type: integer
+          format: int64
+          minimum: 0
+        chunkEnd:
+          type: integer
+          format: int64
+          minimum: 0
+        totalBytes:
+          type: integer
+          format: int64
+          minimum: 1
+        chunkChecksum:
+          type: [string, "null"]
+
+    UploadSessionInfo:
+      type: object
+      required: [uploadSessionId, bookId, status, uploadedBytes, totalBytes]
+      properties:
+        uploadSessionId:
+          type: string
+        bookId:
+          type: string
+        status:
+          type: string
+        uploadedBytes:
+          type: integer
+          format: int64
+        totalBytes:
+          type: integer
+          format: int64
+        expiresAt:
+          type: [string, "null"]
+          format: date-time
+
+    UploadChunkResult:
+      type: object
+      required: [uploadSessionId, acceptedRangeStart, acceptedRangeEnd, uploadedBytes, isComplete]
+      properties:
+        uploadSessionId:
+          type: string
+        acceptedRangeStart:
+          type: integer
+          format: int64
+        acceptedRangeEnd:
+          type: integer
+          format: int64
+        uploadedBytes:
+          type: integer
+          format: int64
+        isComplete:
+          type: boolean
 
     PublishBookRequest:
       type: object

--- a/examples/MockPublishingPlatform.Api/Models/UploadSessionState.cs
+++ b/examples/MockPublishingPlatform.Api/Models/UploadSessionState.cs
@@ -1,0 +1,47 @@
+namespace MockPublishingPlatform.Api.Models;
+
+/// <summary>
+/// Represents in-memory resumable upload session state for the mock API.
+/// </summary>
+public sealed class UploadSessionState
+{
+    /// <summary>
+    /// Gets or sets upload session identifier.
+    /// </summary>
+    public string UploadSessionId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets associated book identifier.
+    /// </summary>
+    public string BookId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets file name.
+    /// </summary>
+    public string FileName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets optional content type.
+    /// </summary>
+    public string? ContentType { get; set; }
+
+    /// <summary>
+    /// Gets or sets optional format.
+    /// </summary>
+    public string? Format { get; set; }
+
+    /// <summary>
+    /// Gets or sets uploaded bytes count.
+    /// </summary>
+    public long UploadedBytes { get; set; }
+
+    /// <summary>
+    /// Gets or sets total bytes.
+    /// </summary>
+    public long TotalBytes { get; set; }
+
+    /// <summary>
+    /// Gets or sets session status.
+    /// </summary>
+    public string Status { get; set; } = "pending";
+}

--- a/examples/MockPublishingPlatform.Api/Program.cs
+++ b/examples/MockPublishingPlatform.Api/Program.cs
@@ -2,6 +2,7 @@ using PublishingPlatform.SDK.Models;
 using PublishingPlatform.SDK.Models.Common;
 using MockPublishingPlatform.Api.Models;
 using MockPublishingPlatform.Api.Services;
+using System.Globalization;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddSingleton(FixtureLoader.Load(Path.Combine(builder.Environment.ContentRootPath, "Fixtures")));
@@ -12,6 +13,7 @@ var publishedAtTimestamp = DateTimeOffset.Parse("2026-05-08T12:01:00Z");
 var distributionStartTimestamp = DateTimeOffset.Parse("2026-05-08T12:02:00Z");
 var webhookCreatedTimestamp = DateTimeOffset.Parse("2026-05-08T12:03:00Z");
 var webhookUpdatedTimestamp = DateTimeOffset.Parse("2026-05-08T12:04:00Z");
+var uploadSessionExpiresAt = DateTimeOffset.Parse("2026-05-09T12:00:00Z");
 
 app.Use(async (context, next) =>
 {
@@ -144,7 +146,6 @@ app.MapPut("/books/{bookId}/content", async (string bookId, HttpRequest httpRequ
         format = Path.GetExtension(file.FileName).Trim('.').ToLowerInvariant();
     }
 
-    var now = DateTimeOffset.Parse("2026-05-08T12:00:00Z");
     var content = new BookContent
     {
         BookId = bookId,
@@ -176,6 +177,169 @@ app.MapGet("/books/{bookId}/content", (string bookId, HttpRequest httpRequest, M
     }
 
     return CreateNotFound(httpRequest, state);
+});
+
+app.MapPost("/books/{bookId}/content/uploads", (string bookId, StartResumableUploadRequest request, HttpRequest httpRequest, MockApiState state) =>
+{
+    if (!state.Books.Any(book => string.Equals(book.Id, bookId, StringComparison.OrdinalIgnoreCase)))
+    {
+        return CreateNotFound(httpRequest, state);
+    }
+
+    if (string.IsNullOrWhiteSpace(request.FileName) || request.TotalBytes <= 0)
+    {
+        return Results.BadRequest(ApiErrorResponse.FromFixture(state.ApiErrors["validation"], httpRequest.HttpContext.TraceIdentifier));
+    }
+
+    var idempotencyKey = IdempotencyHelper.Resolve(httpRequest);
+    if (IdempotencyHelper.TryReplay<UploadSessionInfo>(state, $"POST:/books/{bookId}/content/uploads:{idempotencyKey}", out var replayed))
+    {
+        return Results.Ok(replayed);
+    }
+
+    var sessionId = $"upl-{state.UploadSessions.Count + 1:D4}";
+    state.UploadSessions[sessionId] = new UploadSessionState
+    {
+        UploadSessionId = sessionId,
+        BookId = bookId,
+        FileName = request.FileName.Trim(),
+        ContentType = request.ContentType,
+        Format = request.Format,
+        UploadedBytes = 0,
+        TotalBytes = request.TotalBytes,
+        Status = "pending",
+    };
+
+    var info = new UploadSessionInfo
+    {
+        UploadSessionId = sessionId,
+        BookId = bookId,
+        UploadedBytes = 0,
+        TotalBytes = request.TotalBytes,
+        Status = "pending",
+        ExpiresAt = uploadSessionExpiresAt,
+    };
+
+    if (!string.IsNullOrWhiteSpace(idempotencyKey))
+    {
+        state.IdempotencyResponses[$"POST:/books/{bookId}/content/uploads:{idempotencyKey}"] = info;
+    }
+
+    return Results.Ok(info);
+});
+
+app.MapPut("/books/{bookId}/content/uploads/{uploadSessionId}/chunks", async (string bookId, string uploadSessionId, HttpRequest httpRequest, MockApiState state) =>
+{
+    if (!state.UploadSessions.TryGetValue(uploadSessionId, out var session)
+        || !string.Equals(session.BookId, bookId, StringComparison.OrdinalIgnoreCase))
+    {
+        return CreateNotFound(httpRequest, state);
+    }
+
+    if (!httpRequest.Headers.TryGetValue("Content-Range", out var rangeHeaderValues))
+    {
+        return Results.BadRequest(ApiErrorResponse.FromFixture(state.ApiErrors["validation"], httpRequest.HttpContext.TraceIdentifier));
+    }
+
+    var rangeHeader = rangeHeaderValues.ToString();
+    if (!TryParseContentRange(rangeHeader, out var rangeStart, out var rangeEnd, out var rangeTotal))
+    {
+        return Results.BadRequest(ApiErrorResponse.FromFixture(state.ApiErrors["validation"], httpRequest.HttpContext.TraceIdentifier));
+    }
+
+    if (rangeStart != session.UploadedBytes || rangeTotal != session.TotalBytes || rangeEnd < rangeStart)
+    {
+        return Results.BadRequest(ApiErrorResponse.FromFixture(state.ApiErrors["validation"], httpRequest.HttpContext.TraceIdentifier));
+    }
+
+    if (!httpRequest.ContentLength.HasValue || httpRequest.ContentLength.Value <= 0)
+    {
+        return Results.BadRequest(ApiErrorResponse.FromFixture(state.ApiErrors["validation"], httpRequest.HttpContext.TraceIdentifier));
+    }
+
+    var expectedLength = (rangeEnd - rangeStart) + 1;
+    var actualLength = httpRequest.ContentLength.Value;
+    if (actualLength != expectedLength)
+    {
+        return Results.BadRequest(ApiErrorResponse.FromFixture(state.ApiErrors["validation"], httpRequest.HttpContext.TraceIdentifier));
+    }
+
+    session.UploadedBytes += actualLength;
+    session.Status = session.UploadedBytes == session.TotalBytes ? "uploaded" : "in_progress";
+
+    var chunkResult = new UploadChunkResult
+    {
+        UploadSessionId = uploadSessionId,
+        AcceptedRangeStart = rangeStart,
+        AcceptedRangeEnd = rangeEnd,
+        UploadedBytes = session.UploadedBytes,
+        IsComplete = session.UploadedBytes == session.TotalBytes,
+    };
+
+    return Results.Ok(chunkResult);
+});
+
+app.MapGet("/books/{bookId}/content/uploads/{uploadSessionId}", (string bookId, string uploadSessionId, HttpRequest httpRequest, MockApiState state) =>
+{
+    if (!state.UploadSessions.TryGetValue(uploadSessionId, out var session)
+        || !string.Equals(session.BookId, bookId, StringComparison.OrdinalIgnoreCase))
+    {
+        return CreateNotFound(httpRequest, state);
+    }
+
+    var info = new UploadSessionInfo
+    {
+        UploadSessionId = session.UploadSessionId,
+        BookId = session.BookId,
+        UploadedBytes = session.UploadedBytes,
+        TotalBytes = session.TotalBytes,
+        Status = session.Status,
+        ExpiresAt = uploadSessionExpiresAt,
+    };
+
+    return Results.Ok(info);
+});
+
+app.MapPost("/books/{bookId}/content/uploads/{uploadSessionId}/complete", (string bookId, string uploadSessionId, CompleteResumableUploadRequest _, HttpRequest httpRequest, MockApiState state) =>
+{
+    if (!state.UploadSessions.TryGetValue(uploadSessionId, out var session)
+        || !string.Equals(session.BookId, bookId, StringComparison.OrdinalIgnoreCase))
+    {
+        return CreateNotFound(httpRequest, state);
+    }
+
+    var idempotencyKey = IdempotencyHelper.Resolve(httpRequest);
+    if (IdempotencyHelper.TryReplay<BookContent>(state, $"POST:/books/{bookId}/content/uploads/{uploadSessionId}/complete:{idempotencyKey}", out var replayed))
+    {
+        return Results.Ok(replayed);
+    }
+
+    if (session.UploadedBytes != session.TotalBytes)
+    {
+        return Results.BadRequest(ApiErrorResponse.FromFixture(state.ApiErrors["validation"], httpRequest.HttpContext.TraceIdentifier));
+    }
+
+    session.Status = "completed";
+    var format = string.IsNullOrWhiteSpace(session.Format)
+        ? Path.GetExtension(session.FileName).Trim('.').ToLowerInvariant()
+        : session.Format;
+
+    var content = new BookContent
+    {
+        BookId = bookId,
+        Format = string.IsNullOrWhiteSpace(format) ? "unknown" : format,
+        ContentUrl = new Uri($"https://mock.publisher-platform.dev/content/{Uri.EscapeDataString(bookId)}"),
+        LocalPath = $"/mock-storage/{bookId}/{session.FileName}",
+        StoredAt = storedAtTimestamp,
+    };
+
+    state.BookContents[bookId] = content;
+    if (!string.IsNullOrWhiteSpace(idempotencyKey))
+    {
+        state.IdempotencyResponses[$"POST:/books/{bookId}/content/uploads/{uploadSessionId}/complete:{idempotencyKey}"] = content;
+    }
+
+    return Results.Ok(content);
 });
 
 app.MapPost("/books/{bookId}/publishing/publish", (string bookId, PublishBookRequest _, HttpRequest httpRequest, MockApiState state) =>
@@ -358,4 +522,31 @@ app.Run();
 static IResult CreateNotFound(HttpRequest request, MockApiState state)
 {
     return Results.NotFound(ApiErrorResponse.FromFixture(state.ApiErrors["notFound"], request.HttpContext.TraceIdentifier));
+}
+
+static bool TryParseContentRange(string value, out long rangeStart, out long rangeEnd, out long totalBytes)
+{
+    rangeStart = 0;
+    rangeEnd = 0;
+    totalBytes = 0;
+    if (!value.StartsWith("bytes ", StringComparison.OrdinalIgnoreCase))
+    {
+        return false;
+    }
+
+    var pieces = value["bytes ".Length..].Split('/', StringSplitOptions.TrimEntries);
+    if (pieces.Length != 2)
+    {
+        return false;
+    }
+
+    var range = pieces[0].Split('-', StringSplitOptions.TrimEntries);
+    if (range.Length != 2)
+    {
+        return false;
+    }
+
+    return long.TryParse(range[0], NumberStyles.None, CultureInfo.InvariantCulture, out rangeStart)
+        && long.TryParse(range[1], NumberStyles.None, CultureInfo.InvariantCulture, out rangeEnd)
+        && long.TryParse(pieces[1], NumberStyles.None, CultureInfo.InvariantCulture, out totalBytes);
 }

--- a/examples/MockPublishingPlatform.Api/Services/MockApiState.cs
+++ b/examples/MockPublishingPlatform.Api/Services/MockApiState.cs
@@ -42,4 +42,9 @@ public sealed class MockApiState
     /// Gets idempotency replay cache for mutating operations.
     /// </summary>
     public Dictionary<string, object> IdempotencyResponses { get; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets resumable upload sessions keyed by upload session id.
+    /// </summary>
+    public Dictionary<string, UploadSessionState> UploadSessions { get; } = new(StringComparer.OrdinalIgnoreCase);
 }

--- a/examples/ResumableUpload/README.md
+++ b/examples/ResumableUpload/README.md
@@ -1,0 +1,12 @@
+# ResumableUpload Example
+
+Demonstrates session-based resumable upload flow:
+
+- `StartResumableUploadAsync(...)`
+- `UploadChunkAsync(...)`
+- `GetUploadSessionAsync(...)`
+- `CompleteResumableUploadAsync(...)`
+
+Run:
+
+- `examples/ResumableUpload/ResumableUploadExample.csx`

--- a/examples/ResumableUpload/ResumableUploadExample.csx
+++ b/examples/ResumableUpload/ResumableUploadExample.csx
@@ -1,0 +1,68 @@
+//r "nuget: PublishingPlatform.SDK"
+
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Options;
+
+var baseUrl = Environment.GetEnvironmentVariable("MOCK_API_BASE_URL") ?? "https://localhost:7025";
+var apiKey = Environment.GetEnvironmentVariable("MOCK_API_KEY") ?? "demo-nonsecret-key";
+
+var client = PublishingPlatformClientBuilder.Create(new PublishingPlatformClientOptions
+{
+    BaseUrl = baseUrl,
+    ApiKey = apiKey,
+}).Build();
+
+var created = await client.Books.CreateAsync(new CreateBookRequest
+{
+    Title = "Resumable Upload Demo",
+    Author = "SDK Candidate",
+    Tags = new[] { "demo", "resumable" },
+    IdempotencyKey = "resumable-book-create-1",
+});
+
+var payload = System.Text.Encoding.UTF8.GetBytes("abcdefghijklmnopqrstuvwxyz0123456789");
+var session = await client.BookContent.StartResumableUploadAsync(created.Id, new StartResumableUploadRequest
+{
+    FileName = "resumable-demo.epub",
+    ContentType = "application/epub+zip",
+    Format = "epub",
+    TotalBytes = payload.Length,
+    IdempotencyKey = "resumable-start-1",
+});
+
+var firstChunk = payload.AsMemory(0, 18).ToArray();
+await using (var firstStream = new MemoryStream(firstChunk))
+{
+    _ = await client.BookContent.UploadChunkAsync(created.Id, session.UploadSessionId, new UploadChunkRequest
+    {
+        Chunk = firstStream,
+        ChunkStart = 0,
+        ChunkEnd = firstChunk.Length - 1,
+        TotalBytes = payload.Length,
+    });
+}
+
+session = await client.BookContent.GetUploadSessionAsync(created.Id, session.UploadSessionId);
+var secondStart = session.UploadedBytes;
+var secondChunk = payload.AsMemory((int)secondStart, payload.Length - (int)secondStart).ToArray();
+await using (var secondStream = new MemoryStream(secondChunk))
+{
+    _ = await client.BookContent.UploadChunkAsync(created.Id, session.UploadSessionId, new UploadChunkRequest
+    {
+        Chunk = secondStream,
+        ChunkStart = secondStart,
+        ChunkEnd = secondStart + secondChunk.Length - 1,
+        TotalBytes = payload.Length,
+    });
+}
+
+var completed = await client.BookContent.CompleteResumableUploadAsync(
+    created.Id,
+    session.UploadSessionId,
+    new CompleteResumableUploadRequest
+    {
+        IdempotencyKey = "resumable-complete-1",
+    });
+
+Console.WriteLine($"Resumable upload completed for book {completed.BookId} with format {completed.Format}.");

--- a/examples/ResumableUpload/ResumableUploadExample.csx
+++ b/examples/ResumableUpload/ResumableUploadExample.csx
@@ -1,4 +1,7 @@
-//r "nuget: PublishingPlatform.SDK"
+#r "nuget: Microsoft.Extensions.Http, 9.0.1"
+#r "nuget: Microsoft.Extensions.Http.Resilience, 9.1.0"
+#r "nuget: Polly.Core, 8.4.2"
+#r "../../src/PublishingPlatform.SDK/bin/Debug/net10.0/PublishingPlatform.SDK.dll"
 
 using PublishingPlatform.SDK.Clients;
 using PublishingPlatform.SDK.Models;

--- a/src/PublishingPlatform.SDK/Abstractions/IBookContentClient.cs
+++ b/src/PublishingPlatform.SDK/Abstractions/IBookContentClient.cs
@@ -23,4 +23,42 @@ public interface IBookContentClient
     /// <param name="ct">The cancellation token.</param>
     /// <returns>The updated book content metadata.</returns>
     Task<BookContent> UploadOrReplaceAsync(string bookId, UploadBookContentRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Starts a resumable upload session for a book.
+    /// </summary>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="request">The upload session request.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The created upload session snapshot.</returns>
+    Task<UploadSessionInfo> StartResumableUploadAsync(string bookId, StartResumableUploadRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Uploads one chunk for an existing upload session.
+    /// </summary>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="uploadSessionId">The upload session identifier.</param>
+    /// <param name="request">The chunk upload request.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The accepted chunk result.</returns>
+    Task<UploadChunkResult> UploadChunkAsync(string bookId, string uploadSessionId, UploadChunkRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the current resumable upload session state.
+    /// </summary>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="uploadSessionId">The upload session identifier.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The current upload session snapshot.</returns>
+    Task<UploadSessionInfo> GetUploadSessionAsync(string bookId, string uploadSessionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Completes a resumable upload session and materializes content metadata.
+    /// </summary>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="uploadSessionId">The upload session identifier.</param>
+    /// <param name="request">The completion request.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The completed book content metadata.</returns>
+    Task<BookContent> CompleteResumableUploadAsync(string bookId, string uploadSessionId, CompleteResumableUploadRequest request, CancellationToken ct = default);
 }

--- a/src/PublishingPlatform.SDK/Clients/BookContent/Requests/DefaultBookContentRequestHeadersFactory.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookContent/Requests/DefaultBookContentRequestHeadersFactory.cs
@@ -1,9 +1,13 @@
 using PublishingPlatform.SDK.Infrastructure.Transport;
+using PublishingPlatform.SDK.Models;
 
 namespace PublishingPlatform.SDK.Clients.BookContent.Requests;
 
 internal sealed class DefaultBookContentRequestHeadersFactory : IBookContentRequestHeadersFactory
 {
+    private const string ContentRangeHeaderName = "Content-Range";
+    private const string ChunkChecksumHeaderName = "X-Chunk-Checksum";
+
     public IReadOnlyDictionary<string, string>? CreateIdempotencyHeaders(string? idempotencyKey)
     {
         if (string.IsNullOrWhiteSpace(idempotencyKey))
@@ -15,5 +19,20 @@ internal sealed class DefaultBookContentRequestHeadersFactory : IBookContentRequ
         {
             [TransportHeaderNames.IdempotencyKey] = idempotencyKey,
         };
+    }
+
+    public IReadOnlyDictionary<string, string> CreateChunkHeaders(UploadChunkRequest request)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [ContentRangeHeaderName] = $"bytes {request.ChunkStart}-{request.ChunkEnd}/{request.TotalBytes}",
+        };
+
+        if (!string.IsNullOrWhiteSpace(request.ChunkChecksum))
+        {
+            headers[ChunkChecksumHeaderName] = request.ChunkChecksum;
+        }
+
+        return headers;
     }
 }

--- a/src/PublishingPlatform.SDK/Clients/BookContent/Requests/IBookContentRequestHeadersFactory.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookContent/Requests/IBookContentRequestHeadersFactory.cs
@@ -1,6 +1,10 @@
 namespace PublishingPlatform.SDK.Clients.BookContent.Requests;
 
+using PublishingPlatform.SDK.Models;
+
 internal interface IBookContentRequestHeadersFactory
 {
     IReadOnlyDictionary<string, string>? CreateIdempotencyHeaders(string? idempotencyKey);
+
+    IReadOnlyDictionary<string, string> CreateChunkHeaders(UploadChunkRequest request);
 }

--- a/src/PublishingPlatform.SDK/Clients/BookContent/Serialization/DefaultBookContentResponseReader.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookContent/Serialization/DefaultBookContentResponseReader.cs
@@ -17,4 +17,26 @@ internal sealed class DefaultBookContentResponseReader : IBookContentResponseRea
 
         return content;
     }
+
+    public async Task<UploadSessionInfo> ReadUploadSessionAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        var session = await response.Content.ReadFromJsonAsync<UploadSessionInfo>(cancellationToken).ConfigureAwait(false);
+        if (session is null)
+        {
+            throw new BookValidationException("Upload session payload was empty.");
+        }
+
+        return session;
+    }
+
+    public async Task<UploadChunkResult> ReadUploadChunkResultAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        var result = await response.Content.ReadFromJsonAsync<UploadChunkResult>(cancellationToken).ConfigureAwait(false);
+        if (result is null)
+        {
+            throw new BookValidationException("Upload chunk payload was empty.");
+        }
+
+        return result;
+    }
 }

--- a/src/PublishingPlatform.SDK/Clients/BookContent/Serialization/IBookContentResponseReader.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookContent/Serialization/IBookContentResponseReader.cs
@@ -8,4 +8,8 @@ using BookContentModel = PublishingPlatform.SDK.Models.BookContent;
 internal interface IBookContentResponseReader
 {
     Task<BookContentModel> ReadBookContentAsync(HttpResponseMessage response, CancellationToken cancellationToken);
+
+    Task<UploadSessionInfo> ReadUploadSessionAsync(HttpResponseMessage response, CancellationToken cancellationToken);
+
+    Task<UploadChunkResult> ReadUploadChunkResultAsync(HttpResponseMessage response, CancellationToken cancellationToken);
 }

--- a/src/PublishingPlatform.SDK/Clients/BookContent/Validation/DefaultBookContentRequestValidator.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookContent/Validation/DefaultBookContentRequestValidator.cs
@@ -46,4 +46,63 @@ internal sealed class DefaultBookContentRequestValidator : IBookContentRequestVa
             throw new BookValidationException("File name is required.");
         }
     }
+
+    public void ValidateUploadSessionId(string uploadSessionId)
+    {
+        if (string.IsNullOrWhiteSpace(uploadSessionId))
+        {
+            throw new BookValidationException("Upload session id is required.");
+        }
+    }
+
+    public void ValidateStartResumableUploadRequest(StartResumableUploadRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.FileName))
+        {
+            throw new BookValidationException("File name is required.");
+        }
+
+        if (request.TotalBytes <= 0)
+        {
+            throw new BookValidationException("Total bytes must be greater than zero.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Format) && !AllowedFormats.Contains(request.Format))
+        {
+            throw new BookValidationException($"Format must be one of: {string.Join(", ", AllowedFormats)}.");
+        }
+    }
+
+    public void ValidateUploadChunkRequest(UploadChunkRequest request)
+    {
+        if (request.Chunk == Stream.Null)
+        {
+            throw new BookValidationException("Chunk stream is required.");
+        }
+
+        if (request.Chunk is null || !request.Chunk.CanRead)
+        {
+            throw new BookValidationException("Chunk stream must be readable.");
+        }
+
+        if (request.TotalBytes <= 0)
+        {
+            throw new BookValidationException("Total bytes must be greater than zero.");
+        }
+
+        if (request.ChunkStart < 0 || request.ChunkEnd < 0)
+        {
+            throw new BookValidationException("Chunk range offsets must be non-negative.");
+        }
+
+        if (request.ChunkStart > request.ChunkEnd)
+        {
+            throw new BookValidationException("Chunk start must be less than or equal to chunk end.");
+        }
+
+        if (request.ChunkEnd >= request.TotalBytes)
+        {
+            throw new BookValidationException("Chunk end must be less than total bytes.");
+        }
+    }
 }

--- a/src/PublishingPlatform.SDK/Clients/BookContent/Validation/IBookContentRequestValidator.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookContent/Validation/IBookContentRequestValidator.cs
@@ -7,4 +7,10 @@ internal interface IBookContentRequestValidator
     void ValidateBookId(string bookId);
 
     void ValidateUploadRequest(UploadBookContentRequest request);
+
+    void ValidateUploadSessionId(string uploadSessionId);
+
+    void ValidateStartResumableUploadRequest(StartResumableUploadRequest request);
+
+    void ValidateUploadChunkRequest(UploadChunkRequest request);
 }

--- a/src/PublishingPlatform.SDK/Clients/BookContentClient.cs
+++ b/src/PublishingPlatform.SDK/Clients/BookContentClient.cs
@@ -6,6 +6,7 @@ using PublishingPlatform.SDK.Infrastructure.Transport;
 using PublishingPlatform.SDK.Internal;
 using PublishingPlatform.SDK.Models;
 using BookContentModel = PublishingPlatform.SDK.Models.BookContent;
+using System.Net.Http.Json;
 
 namespace PublishingPlatform.SDK.Clients;
 
@@ -16,6 +17,10 @@ public sealed class BookContentClient : IBookContentClient
 {
     private const string GetOperationName = "BookContent.Get";
     private const string UploadOrReplaceOperationName = "BookContent.UploadOrReplace";
+    private const string StartResumableUploadOperationName = "BookContent.StartResumableUpload";
+    private const string UploadChunkOperationName = "BookContent.UploadChunk";
+    private const string GetUploadSessionOperationName = "BookContent.GetUploadSession";
+    private const string CompleteResumableUploadOperationName = "BookContent.CompleteResumableUpload";
 
     private readonly ISharedHttpTransport _transport;
     private readonly IBookContentRequestValidator _validator;
@@ -78,6 +83,84 @@ public sealed class BookContentClient : IBookContentClient
             content,
             headers,
             UploadOrReplaceOperationName,
+            ct).ConfigureAwait(false);
+
+        return await _responseReader.ReadBookContentAsync(response, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<UploadSessionInfo> StartResumableUploadAsync(string bookId, StartResumableUploadRequest request, CancellationToken ct = default)
+    {
+        _validator.ValidateBookId(bookId);
+        Guards.NotNull(request, nameof(request));
+        _validator.ValidateStartResumableUploadRequest(request);
+
+        var headers = _requestHeadersFactory.CreateIdempotencyHeaders(request.IdempotencyKey);
+        var content = JsonContent.Create(request);
+        using var response = await _transport.SendAsync(
+            HttpMethod.Post,
+            $"/books/{Uri.EscapeDataString(bookId)}/content/uploads",
+            content,
+            headers,
+            StartResumableUploadOperationName,
+            ct).ConfigureAwait(false);
+
+        return await _responseReader.ReadUploadSessionAsync(response, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<UploadChunkResult> UploadChunkAsync(string bookId, string uploadSessionId, UploadChunkRequest request, CancellationToken ct = default)
+    {
+        _validator.ValidateBookId(bookId);
+        _validator.ValidateUploadSessionId(uploadSessionId);
+        Guards.NotNull(request, nameof(request));
+        _validator.ValidateUploadChunkRequest(request);
+
+        using var chunkContent = new StreamContent(request.Chunk);
+        var headers = _requestHeadersFactory.CreateChunkHeaders(request);
+        using var response = await _transport.SendAsync(
+            HttpMethod.Put,
+            $"/books/{Uri.EscapeDataString(bookId)}/content/uploads/{Uri.EscapeDataString(uploadSessionId)}/chunks",
+            chunkContent,
+            headers,
+            UploadChunkOperationName,
+            ct).ConfigureAwait(false);
+
+        return await _responseReader.ReadUploadChunkResultAsync(response, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<UploadSessionInfo> GetUploadSessionAsync(string bookId, string uploadSessionId, CancellationToken ct = default)
+    {
+        _validator.ValidateBookId(bookId);
+        _validator.ValidateUploadSessionId(uploadSessionId);
+
+        using var response = await _transport.SendAsync(
+            HttpMethod.Get,
+            $"/books/{Uri.EscapeDataString(bookId)}/content/uploads/{Uri.EscapeDataString(uploadSessionId)}",
+            null,
+            null,
+            GetUploadSessionOperationName,
+            ct).ConfigureAwait(false);
+
+        return await _responseReader.ReadUploadSessionAsync(response, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<BookContentModel> CompleteResumableUploadAsync(string bookId, string uploadSessionId, CompleteResumableUploadRequest request, CancellationToken ct = default)
+    {
+        _validator.ValidateBookId(bookId);
+        _validator.ValidateUploadSessionId(uploadSessionId);
+        Guards.NotNull(request, nameof(request));
+
+        var headers = _requestHeadersFactory.CreateIdempotencyHeaders(request.IdempotencyKey);
+        var content = JsonContent.Create(request);
+        using var response = await _transport.SendAsync(
+            HttpMethod.Post,
+            $"/books/{Uri.EscapeDataString(bookId)}/content/uploads/{Uri.EscapeDataString(uploadSessionId)}/complete",
+            content,
+            headers,
+            CompleteResumableUploadOperationName,
             ct).ConfigureAwait(false);
 
         return await _responseReader.ReadBookContentAsync(response, ct).ConfigureAwait(false);

--- a/src/PublishingPlatform.SDK/Models/CompleteResumableUploadRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/CompleteResumableUploadRequest.cs
@@ -1,0 +1,17 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents completion metadata for a resumable upload session.
+/// </summary>
+public sealed class CompleteResumableUploadRequest
+{
+    /// <summary>
+    /// Gets or sets optional final checksum.
+    /// </summary>
+    public string? FinalChecksum { get; set; }
+
+    /// <summary>
+    /// Gets or sets optional idempotency key for safe retries.
+    /// </summary>
+    public string? IdempotencyKey { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Models/StartResumableUploadRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/StartResumableUploadRequest.cs
@@ -1,0 +1,32 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents input required to create a resumable upload session.
+/// </summary>
+public sealed class StartResumableUploadRequest
+{
+    /// <summary>
+    /// Gets or sets the file name associated with the upload.
+    /// </summary>
+    public string FileName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the optional media content type (for example application/pdf).
+    /// </summary>
+    public string? ContentType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional format (for example pdf or epub).
+    /// </summary>
+    public string? Format { get; set; }
+
+    /// <summary>
+    /// Gets or sets total file size in bytes.
+    /// </summary>
+    public long TotalBytes { get; set; }
+
+    /// <summary>
+    /// Gets or sets optional idempotency key for safe retries.
+    /// </summary>
+    public string? IdempotencyKey { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Models/UploadChunkRequest.cs
+++ b/src/PublishingPlatform.SDK/Models/UploadChunkRequest.cs
@@ -1,0 +1,32 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents one resumable upload chunk payload.
+/// </summary>
+public sealed class UploadChunkRequest
+{
+    /// <summary>
+    /// Gets or sets the chunk stream.
+    /// </summary>
+    public Stream Chunk { get; set; } = Stream.Null;
+
+    /// <summary>
+    /// Gets or sets the inclusive chunk start offset.
+    /// </summary>
+    public long ChunkStart { get; set; }
+
+    /// <summary>
+    /// Gets or sets the inclusive chunk end offset.
+    /// </summary>
+    public long ChunkEnd { get; set; }
+
+    /// <summary>
+    /// Gets or sets the full file size in bytes.
+    /// </summary>
+    public long TotalBytes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional chunk checksum.
+    /// </summary>
+    public string? ChunkChecksum { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Models/UploadChunkResult.cs
+++ b/src/PublishingPlatform.SDK/Models/UploadChunkResult.cs
@@ -1,0 +1,32 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents accepted range details for an uploaded chunk.
+/// </summary>
+public sealed class UploadChunkResult
+{
+    /// <summary>
+    /// Gets or sets the upload session identifier.
+    /// </summary>
+    public string UploadSessionId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets accepted chunk start offset.
+    /// </summary>
+    public long AcceptedRangeStart { get; set; }
+
+    /// <summary>
+    /// Gets or sets accepted chunk end offset.
+    /// </summary>
+    public long AcceptedRangeEnd { get; set; }
+
+    /// <summary>
+    /// Gets or sets cumulative uploaded bytes.
+    /// </summary>
+    public long UploadedBytes { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether all bytes were uploaded.
+    /// </summary>
+    public bool IsComplete { get; set; }
+}

--- a/src/PublishingPlatform.SDK/Models/UploadSessionInfo.cs
+++ b/src/PublishingPlatform.SDK/Models/UploadSessionInfo.cs
@@ -1,0 +1,37 @@
+namespace PublishingPlatform.SDK.Models;
+
+/// <summary>
+/// Represents resumable upload session progress and state.
+/// </summary>
+public sealed class UploadSessionInfo
+{
+    /// <summary>
+    /// Gets or sets the unique upload session identifier.
+    /// </summary>
+    public string UploadSessionId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the associated book identifier.
+    /// </summary>
+    public string BookId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets session status value.
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets uploaded bytes count.
+    /// </summary>
+    public long UploadedBytes { get; set; }
+
+    /// <summary>
+    /// Gets or sets total file bytes.
+    /// </summary>
+    public long TotalBytes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the session expiration timestamp.
+    /// </summary>
+    public DateTimeOffset? ExpiresAt { get; set; }
+}

--- a/tests/PublishingPlatform.SDK.Tests/BookContent/BookContentClientTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/BookContent/BookContentClientTests.cs
@@ -162,6 +162,158 @@ public sealed class BookContentClientTests
         ex.Which.Message.Should().Contain("Book content payload was empty");
     }
 
+    [Fact]
+    public async Task StartResumableUploadAsync_SendsPostWithIdempotencyHeader()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+                HttpMethod.Post,
+                "/books/book-3/content/uploads",
+                Arg.Any<HttpContent>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                "BookContent.StartResumableUpload",
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new UploadSessionInfo
+                {
+                    UploadSessionId = "upl-1",
+                    BookId = "book-3",
+                    Status = "pending",
+                    UploadedBytes = 0,
+                    TotalBytes = 10,
+                }),
+            }));
+
+        var sut = new BookContentClient(transport);
+        var result = await sut.StartResumableUploadAsync("book-3", new StartResumableUploadRequest
+        {
+            FileName = "demo.epub",
+            Format = "epub",
+            TotalBytes = 10,
+            IdempotencyKey = "start-1",
+        });
+
+        result.UploadSessionId.Should().Be("upl-1");
+        await transport.Received(1).SendAsync(
+            HttpMethod.Post,
+            "/books/book-3/content/uploads",
+            Arg.Any<HttpContent>(),
+            Arg.Is<IReadOnlyDictionary<string, string>>(headers => headers["Idempotency-Key"] == "start-1"),
+            "BookContent.StartResumableUpload",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UploadChunkAsync_SendsPutWithContentRangeHeader()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+                HttpMethod.Put,
+                "/books/book-3/content/uploads/upl-1/chunks",
+                Arg.Any<HttpContent>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                "BookContent.UploadChunk",
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new UploadChunkResult
+                {
+                    UploadSessionId = "upl-1",
+                    AcceptedRangeStart = 0,
+                    AcceptedRangeEnd = 4,
+                    UploadedBytes = 5,
+                    IsComplete = false,
+                }),
+            }));
+
+        var sut = new BookContentClient(transport);
+        await using var chunk = new MemoryStream(Encoding.UTF8.GetBytes("chunk"));
+        var result = await sut.UploadChunkAsync("book-3", "upl-1", new UploadChunkRequest
+        {
+            Chunk = chunk,
+            ChunkStart = 0,
+            ChunkEnd = 4,
+            TotalBytes = 10,
+            ChunkChecksum = "sha256:abc",
+        });
+
+        result.UploadedBytes.Should().Be(5);
+        await transport.Received(1).SendAsync(
+            HttpMethod.Put,
+            "/books/book-3/content/uploads/upl-1/chunks",
+            Arg.Any<HttpContent>(),
+            Arg.Is<IReadOnlyDictionary<string, string>>(headers =>
+                headers["Content-Range"] == "bytes 0-4/10"
+                && headers["X-Chunk-Checksum"] == "sha256:abc"),
+            "BookContent.UploadChunk",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetUploadSessionAsync_SendsGetToExpectedPath()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+                HttpMethod.Get,
+                "/books/book-3/content/uploads/upl-1",
+                null,
+                null,
+                "BookContent.GetUploadSession",
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new UploadSessionInfo
+                {
+                    UploadSessionId = "upl-1",
+                    BookId = "book-3",
+                    Status = "in_progress",
+                    UploadedBytes = 5,
+                    TotalBytes = 10,
+                }),
+            }));
+
+        var sut = new BookContentClient(transport);
+        var result = await sut.GetUploadSessionAsync("book-3", "upl-1");
+        result.Status.Should().Be("in_progress");
+    }
+
+    [Fact]
+    public async Task CompleteResumableUploadAsync_SendsPostWithIdempotencyHeader()
+    {
+        var transport = Substitute.For<ISharedHttpTransport>();
+        transport.SendAsync(
+                HttpMethod.Post,
+                "/books/book-3/content/uploads/upl-1/complete",
+                Arg.Any<HttpContent>(),
+                Arg.Any<IReadOnlyDictionary<string, string>>(),
+                "BookContent.CompleteResumableUpload",
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent.Create(new Models.BookContent
+                {
+                    BookId = "book-3",
+                    Format = "epub",
+                }),
+            }));
+
+        var sut = new BookContentClient(transport);
+        var result = await sut.CompleteResumableUploadAsync("book-3", "upl-1", new CompleteResumableUploadRequest
+        {
+            IdempotencyKey = "complete-1",
+        });
+
+        result.BookId.Should().Be("book-3");
+        await transport.Received(1).SendAsync(
+            HttpMethod.Post,
+            "/books/book-3/content/uploads/upl-1/complete",
+            Arg.Any<HttpContent>(),
+            Arg.Is<IReadOnlyDictionary<string, string>>(headers => headers["Idempotency-Key"] == "complete-1"),
+            "BookContent.CompleteResumableUpload",
+            Arg.Any<CancellationToken>());
+    }
+
     private sealed class SingleResponseHandler : HttpMessageHandler
     {
         private readonly HttpResponseMessage _response;

--- a/tests/PublishingPlatform.SDK.Tests/BookContent/BookContentResponseReaderTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/BookContent/BookContentResponseReaderTests.cs
@@ -1,0 +1,46 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using PublishingPlatform.SDK.Clients.BookContent.Serialization;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Tests.BookContent;
+
+public sealed class BookContentResponseReaderTests
+{
+    [Fact]
+    public async Task ReadUploadSessionAsync_Throws_WhenPayloadIsNull()
+    {
+        var reader = new DefaultBookContentResponseReader();
+        using var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, "application/json"),
+        };
+
+        var act = async () => await reader.ReadUploadSessionAsync(response, CancellationToken.None);
+        var ex = await act.Should().ThrowAsync<BookValidationException>();
+        ex.Which.Message.Should().Contain("Upload session payload was empty");
+    }
+
+    [Fact]
+    public async Task ReadUploadChunkResultAsync_MapsPayload()
+    {
+        var reader = new DefaultBookContentResponseReader();
+        using var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(new UploadChunkResult
+            {
+                UploadSessionId = "upl-1",
+                AcceptedRangeStart = 0,
+                AcceptedRangeEnd = 4,
+                UploadedBytes = 5,
+                IsComplete = false,
+            }),
+        };
+
+        var result = await reader.ReadUploadChunkResultAsync(response, CancellationToken.None);
+        result.UploadSessionId.Should().Be("upl-1");
+        result.UploadedBytes.Should().Be(5);
+    }
+}

--- a/tests/PublishingPlatform.SDK.Tests/BookContent/BookContentResumableValidatorTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/BookContent/BookContentResumableValidatorTests.cs
@@ -1,0 +1,59 @@
+using PublishingPlatform.SDK.Clients.BookContent.Validation;
+using PublishingPlatform.SDK.Exceptions;
+using PublishingPlatform.SDK.Models;
+
+namespace PublishingPlatform.SDK.Tests.BookContent;
+
+public sealed class BookContentResumableValidatorTests
+{
+    private static readonly DefaultBookContentRequestValidator Sut = new();
+
+    [Fact]
+    public void ValidateUploadSessionId_Throws_WhenMissing()
+    {
+        var act = () => Sut.ValidateUploadSessionId(" ");
+        act.Should().Throw<BookValidationException>().WithMessage("*Upload session id is required*");
+    }
+
+    [Fact]
+    public void ValidateStartResumableUploadRequest_Throws_WhenTotalBytesInvalid()
+    {
+        var act = () => Sut.ValidateStartResumableUploadRequest(new StartResumableUploadRequest
+        {
+            FileName = "demo.epub",
+            TotalBytes = 0,
+        });
+
+        act.Should().Throw<BookValidationException>().WithMessage("*Total bytes must be greater than zero*");
+    }
+
+    [Fact]
+    public async Task ValidateUploadChunkRequest_Throws_WhenRangeInvalid()
+    {
+        await using var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+        var act = () => Sut.ValidateUploadChunkRequest(new UploadChunkRequest
+        {
+            Chunk = stream,
+            ChunkStart = 10,
+            ChunkEnd = 5,
+            TotalBytes = 20,
+        });
+
+        act.Should().Throw<BookValidationException>().WithMessage("*Chunk start must be less than or equal to chunk end*");
+    }
+
+    [Fact]
+    public async Task ValidateUploadChunkRequest_Throws_WhenChunkEndOutOfBounds()
+    {
+        await using var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+        var act = () => Sut.ValidateUploadChunkRequest(new UploadChunkRequest
+        {
+            Chunk = stream,
+            ChunkStart = 0,
+            ChunkEnd = 20,
+            TotalBytes = 20,
+        });
+
+        act.Should().Throw<BookValidationException>().WithMessage("*Chunk end must be less than total bytes*");
+    }
+}

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/MockApiContractsTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/MockApiContractsTests.cs
@@ -56,6 +56,28 @@ public sealed class MockApiContractsTests
         parsed.Should().Be(expected);
     }
 
+    [Fact]
+    public void UploadSessionState_CanTrackPartialAndCompleteProgress()
+    {
+        var session = new UploadSessionState
+        {
+            UploadSessionId = "upl-1",
+            BookId = "book-1",
+            FileName = "demo.epub",
+            TotalBytes = 10,
+            UploadedBytes = 0,
+            Status = "pending",
+        };
+
+        session.UploadedBytes += 4;
+        session.Status = "in_progress";
+        session.UploadedBytes += 6;
+        session.Status = session.UploadedBytes == session.TotalBytes ? "completed" : "in_progress";
+
+        session.UploadedBytes.Should().Be(10);
+        session.Status.Should().Be("completed");
+    }
+
     private static string ResolveFixturesPath()
     {
         var current = new DirectoryInfo(AppContext.BaseDirectory);

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/ModuleContractConformanceTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/ModuleContractConformanceTests.cs
@@ -13,7 +13,7 @@ namespace PublishingPlatform.SDK.Tests.Infrastructure;
 [Trait("Category", "ContractConformance")]
 public sealed class ModuleContractConformanceTests
 {
-    private const string ExpectedContractShapeHash = "d7c7859c15bdeb7e028af604dc19fc70482885ef7fae05b1138a0e7de1141d7f";
+    private const string ExpectedContractShapeHash = "67cde6a14c0d25451f81f613d8baa13e2d42511506731c4303f0c9fd1298b2fb";
 
     private static readonly (string Name, Type InterfaceType)[] ExpectedPublishingPlatformClientProperties =
     {
@@ -67,7 +67,7 @@ public sealed class ModuleContractConformanceTests
             update ExpectedContractShapeHash to: {actualHash}
             """);
 
-        methods.Should().HaveCount(30);
+        methods.Should().HaveCount(34);
     }
 
     [Fact]

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/OpenApiSpecificationContractsTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/OpenApiSpecificationContractsTests.cs
@@ -10,7 +10,7 @@ namespace PublishingPlatform.SDK.Tests.Infrastructure;
 public sealed class OpenApiSpecificationContractsTests
 {
     private const string SpecRelativePath = @"docs\openapi-google-books-derived-sdk-contract.yaml";
-    private const string ExpectedSha256 = "609c98a5f73c2753d039e4579206cbff60d53bdea992e942486304d2fd0aaa3d";
+    private const string ExpectedSha256 = "5f0e1359264f6e8a6758777c42f64bd41e3ad0385ea2c63be5799f891d4d9f0f";
 
     private static readonly string[] ExpectedOperations =
     {
@@ -21,6 +21,7 @@ public sealed class OpenApiSpecificationContractsTests
         "GET /book-audit-logs",
         "GET /books",
         "GET /books/{bookId}",
+        "GET /books/{bookId}/content/uploads/{uploadSessionId}",
         "GET /books/{bookId}/access",
         "GET /books/{bookId}/access/check",
         "GET /books/{bookId}/content",
@@ -33,6 +34,8 @@ public sealed class OpenApiSpecificationContractsTests
         "POST /books",
         "POST /books/{bookId}/access",
         "POST /books/{bookId}/access/revoke",
+        "POST /books/{bookId}/content/uploads",
+        "POST /books/{bookId}/content/uploads/{uploadSessionId}/complete",
         "POST /books/{bookId}/distribution/{operationId}/retry",
         "POST /books/{bookId}/distribution/start",
         "POST /books/{bookId}/publishing/publish",
@@ -40,6 +43,7 @@ public sealed class OpenApiSpecificationContractsTests
         "POST /books/{bookId}/publishing/unpublish",
         "POST /webhooks",
         "PUT /books/{bookId}",
+        "PUT /books/{bookId}/content/uploads/{uploadSessionId}/chunks",
         "PUT /books/{bookId}/content",
     };
 
@@ -63,6 +67,10 @@ public sealed class OpenApiSpecificationContractsTests
         new(typeof(IBooksClient), nameof(IBooksClient.DeleteAsync), ["books_delete"]),
         new(typeof(IBookContentClient), nameof(IBookContentClient.GetAsync), ["bookContent_get"]),
         new(typeof(IBookContentClient), nameof(IBookContentClient.UploadOrReplaceAsync), ["bookContent_uploadOrReplace"]),
+        new(typeof(IBookContentClient), nameof(IBookContentClient.StartResumableUploadAsync), ["bookContent_startResumableUpload"]),
+        new(typeof(IBookContentClient), nameof(IBookContentClient.UploadChunkAsync), ["bookContent_uploadChunk"]),
+        new(typeof(IBookContentClient), nameof(IBookContentClient.GetUploadSessionAsync), ["bookContent_getUploadSession"]),
+        new(typeof(IBookContentClient), nameof(IBookContentClient.CompleteResumableUploadAsync), ["bookContent_completeResumableUpload"]),
         new(typeof(IBookPublishingClient), nameof(IBookPublishingClient.PublishAsync), ["bookPublishing_publish"]),
         new(typeof(IBookPublishingClient), nameof(IBookPublishingClient.UnpublishAsync), ["bookPublishing_unpublish"]),
         new(typeof(IBookPublishingClient), nameof(IBookPublishingClient.ScheduleAsync), ["bookPublishing_schedule"]),
@@ -105,7 +113,7 @@ public sealed class OpenApiSpecificationContractsTests
         var expectedOperations = ExpectedOperations.OrderBy(x => x, StringComparer.Ordinal).ToArray();
 
         operations.Should().Equal(expectedOperations);
-        operations.Should().HaveCount(27);
+        operations.Should().HaveCount(31);
     }
 
     [Fact]

--- a/tests/PublishingPlatform.SDK.Tests/MockApi/ApiErrorResponseTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/MockApi/ApiErrorResponseTests.cs
@@ -1,0 +1,25 @@
+using MockPublishingPlatform.Api.Models;
+
+namespace PublishingPlatform.SDK.Tests.MockApi;
+
+public sealed class ApiErrorResponseTests
+{
+    [Fact]
+    public void FromFixture_MapsFieldsAndRequestId()
+    {
+        var fixture = new ApiErrorFixture
+        {
+            StatusCode = 400,
+            ErrorCode = "validation_error",
+            Message = "Validation failed",
+        };
+
+        var result = ApiErrorResponse.FromFixture(fixture, "req-123");
+
+        result.Message.Should().Be("Validation failed");
+        result.ErrorCode.Should().Be("validation_error");
+        result.RequestId.Should().Be("req-123");
+        result.CorrelationId.Should().BeNull();
+    }
+}
+

--- a/tests/PublishingPlatform.SDK.Tests/MockApi/IdempotencyHelperTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/MockApi/IdempotencyHelperTests.cs
@@ -1,0 +1,60 @@
+using Microsoft.AspNetCore.Http;
+using MockPublishingPlatform.Api.Services;
+
+namespace PublishingPlatform.SDK.Tests.MockApi;
+
+public sealed class IdempotencyHelperTests
+{
+    [Fact]
+    public void Resolve_ReturnsNullWhenHeaderMissing()
+    {
+        var request = new DefaultHttpContext().Request;
+
+        IdempotencyHelper.Resolve(request).Should().BeNull();
+    }
+
+    [Fact]
+    public void Resolve_TrimsAndReturnsHeaderValue()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers["Idempotency-Key"] = "  demo-key  ";
+
+        IdempotencyHelper.Resolve(context.Request).Should().Be("demo-key");
+    }
+
+    [Fact]
+    public void Resolve_ReturnsNullForWhitespaceHeader()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers["Idempotency-Key"] = "   ";
+
+        IdempotencyHelper.Resolve(context.Request).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryReplay_ReturnsTrueWhenStoredTypeMatches()
+    {
+        var state = CreateState();
+        state.IdempotencyResponses["op:1"] = "payload";
+
+        var found = IdempotencyHelper.TryReplay<string>(state, "op:1", out var replayed);
+
+        found.Should().BeTrue();
+        replayed.Should().Be("payload");
+    }
+
+    [Fact]
+    public void TryReplay_ReturnsFalseWhenTypeDiffersOrKeyMissing()
+    {
+        var state = CreateState();
+        state.IdempotencyResponses["op:1"] = 42;
+
+        IdempotencyHelper.TryReplay<string>(state, "op:1", out var replayed).Should().BeFalse();
+        replayed.Should().BeNull();
+
+        IdempotencyHelper.TryReplay<string>(state, "missing", out var replayedMissing).Should().BeFalse();
+        replayedMissing.Should().BeNull();
+    }
+
+    private static MockApiState CreateState() => new();
+}

--- a/tests/PublishingPlatform.SDK.Tests/MockApi/QueryParserTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/MockApi/QueryParserTests.cs
@@ -1,0 +1,61 @@
+using MockPublishingPlatform.Api.Services;
+
+namespace PublishingPlatform.SDK.Tests.MockApi;
+
+public sealed class QueryParserTests
+{
+    [Theory]
+    [InlineData(null, 10, 1, 100, 10)]
+    [InlineData("oops", 10, 1, 100, 10)]
+    [InlineData("-1", 10, 1, 100, 1)]
+    [InlineData("101", 10, 1, 100, 100)]
+    [InlineData("42", 10, 1, 100, 42)]
+    public void ParsePositiveInt_ClampsAndFallsBack(string? raw, int fallback, int min, int max, int expected)
+    {
+        QueryParser.ParsePositiveInt(raw, fallback, min, max).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null, 5, 5)]
+    [InlineData("oops", 5, 5)]
+    [InlineData("-2", 5, 5)]
+    [InlineData("0", 5, 0)]
+    [InlineData("9", 5, 9)]
+    public void ParseNonNegativeInt_UsesDefaultForInvalidOrNegative(string? raw, int fallback, int expected)
+    {
+        QueryParser.ParseNonNegativeInt(raw, fallback).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("true", false, true)]
+    [InlineData("false", true, false)]
+    [InlineData("oops", true, true)]
+    public void ParseBoolean_UsesFallbackWhenInvalid(string? raw, bool fallback, bool expected)
+    {
+        QueryParser.ParseBoolean(raw, fallback).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    [InlineData("oops", null)]
+    [InlineData(null, null)]
+    public void ParseNullableBoolean_ReturnsNullWhenInvalid(string? raw, bool? expected)
+    {
+        QueryParser.ParseNullableBoolean(raw).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null, 0)]
+    [InlineData("", 0)]
+    [InlineData("offset:8", 8)]
+    [InlineData("OFFSET:11", 11)]
+    [InlineData("offset:-1", 0)]
+    [InlineData("bad:12", 0)]
+    [InlineData("offset:oops", 0)]
+    public void ParseContinuationOffset_ParsesOnlyValidOffsetTokens(string? raw, int expected)
+    {
+        QueryParser.ParseContinuationOffset(raw).Should().Be(expected);
+    }
+}
+


### PR DESCRIPTION
# Summary

Implements resumable upload v1 for `BookContent` with explicit session/chunk/complete flow while preserving backward compatibility for `UploadOrReplaceAsync`.

### What changed

- Added resumable APIs to `IBookContentClient`:
  - `StartResumableUploadAsync`
  - `UploadChunkAsync`
  - `GetUploadSessionAsync`
  - `CompleteResumableUploadAsync`
- Added new SDK models:
  - `StartResumableUploadRequest`
  - `UploadChunkRequest`
  - `CompleteResumableUploadRequest`
  - `UploadSessionInfo`
  - `UploadChunkResult`
- Implemented resumable orchestration in `BookContentClient` for:
  - `POST /books/{bookId}/content/uploads`
  - `PUT /books/{bookId}/content/uploads/{uploadSessionId}/chunks`
  - `GET /books/{bookId}/content/uploads/{uploadSessionId}`
  - `POST /books/{bookId}/content/uploads/{uploadSessionId}/complete`
- Added resumable validation/header/response collaborators:
  - request validation for session/chunk inputs
  - `Content-Range` and idempotency header construction
  - typed session/chunk response reading
- Updated OpenAPI contract with resumable endpoints and schemas.
- Extended `examples/MockPublishingPlatform.Api` with deterministic in-memory upload session and chunk progress behavior.
- Added runnable example script:
  - `examples/ResumableUpload/ResumableUploadExample.csx`
- Updated README with guidance for simple vs resumable upload usage.
- Added mock/helper unit tests to raise coverage above 80%.

### API impact

- Additive, non-breaking public surface change.
- Existing `UploadOrReplaceAsync` behavior remains unchanged.

# Validation

- [x] `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal`
- [x] `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal --collect "XPlat Code Coverage"`
- [x] Resumable example executed against mock API:
  - Output: `Resumable upload completed for book book-0003 with format epub.`
- [x] Coverage after added tests:
  - Line: `80.24%`
  - Branch: `70.78%`

# Release Please Override (Required for releasable changes)

```text
BEGIN_COMMIT_OVERRIDE
feat(book-content): add resumable upload session and chunk workflow
END_COMMIT_OVERRIDE
```

# Manual NuGet Publish

- [ ] Confirm `Directory.Build.props` version equals intended release version.
- [ ] Create matching tag `v<version>` on this exact commit.
- [ ] Run `Publish NuGet` workflow manually with that tag.
- [ ] Verify package version is published on NuGet.
