### PR TITLE
RPS-110 feat(request-options): propagate request-scoped correlation id

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -104,12 +104,18 @@ jobs:
         if: ${{ env.SONAR_TOKEN != '' }}
         shell: powershell
         run: |
-          ${{ runner.temp }}\scanner\dotnet-sonarscanner begin /k:"pavsavov_reading-platform-sdk-csharp" /o:"pavsavov" /d:sonar.token="$env:SONAR_TOKEN" /d:sonar.cs.opencover.reportsPaths="**/TestResults/Coverage/coverage.opencover.xml"
+          $coveragePath = "tests/PublishingPlatform.SDK.Tests/TestResults/Coverage/coverage.opencover.xml"
+          ${{ runner.temp }}\scanner\dotnet-sonarscanner begin /k:"pavsavov_reading-platform-sdk-csharp" /o:"pavsavov" /d:sonar.token="$env:SONAR_TOKEN" /d:sonar.cs.opencover.reportsPaths="$coveragePath" /d:sonar.verbose=true
           dotnet build .\PublishingPlatform.SDK.sln --configuration Release --no-restore
           dotnet test .\PublishingPlatform.SDK.sln `
             --configuration Release `
             --no-build `
             /p:CollectCoverage=true `
             /p:CoverletOutputFormat=opencover `
-            /p:CoverletOutput=./TestResults/Coverage/
+            /p:CoverletOutput=tests/PublishingPlatform.SDK.Tests/TestResults/Coverage/
+          if (!(Test-Path $coveragePath)) {
+            Write-Error "Coverage report not found at expected path: $coveragePath"
+            exit 1
+          }
+          Get-Item $coveragePath | Select-Object FullName, Length, LastWriteTime | Format-List
           ${{ runner.temp }}\scanner\dotnet-sonarscanner end /d:sonar.token="$env:SONAR_TOKEN"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,6 +53,10 @@ jobs:
         shell: powershell
         run: dotnet build .\PublishingPlatform.SDK.sln --configuration Release --no-restore
 
+      - name: Build mock API example
+        shell: powershell
+        run: dotnet build .\examples\MockPublishingPlatform.Api\MockPublishingPlatform.Api.csproj --configuration Release --no-restore
+
       - name: Test with coverage
         if: ${{ env.SONAR_TOKEN == '' }}
         shell: powershell
@@ -67,6 +71,10 @@ jobs:
       - name: Dependency vulnerability audit
         shell: powershell
         run: dotnet list .\PublishingPlatform.SDK.sln package --vulnerable --include-transitive
+
+      - name: Pack SDK
+        shell: powershell
+        run: dotnet pack .\src\PublishingPlatform.SDK\PublishingPlatform.SDK.csproj --configuration Release --no-build --output .\artifacts\ci-pack
 
       - name: Cache SonarQube packages
         if: ${{ env.SONAR_TOKEN != '' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -104,7 +104,8 @@ jobs:
         if: ${{ env.SONAR_TOKEN != '' }}
         shell: powershell
         run: |
-          $coveragePath = "tests/PublishingPlatform.SDK.Tests/TestResults/Coverage/coverage.opencover.xml"
+          $coverageDir = "TestResults/Coverage"
+          $coveragePath = "tests/PublishingPlatform.SDK.Tests/$coverageDir/coverage.opencover.xml"
           ${{ runner.temp }}\scanner\dotnet-sonarscanner begin /k:"pavsavov_reading-platform-sdk-csharp" /o:"pavsavov" /d:sonar.token="$env:SONAR_TOKEN" /d:sonar.cs.opencover.reportsPaths="$coveragePath" /d:sonar.verbose=true
           dotnet build .\PublishingPlatform.SDK.sln --configuration Release --no-restore
           dotnet test .\PublishingPlatform.SDK.sln `
@@ -112,9 +113,17 @@ jobs:
             --no-build `
             /p:CollectCoverage=true `
             /p:CoverletOutputFormat=opencover `
-            /p:CoverletOutput=tests/PublishingPlatform.SDK.Tests/TestResults/Coverage/
+            /p:CoverletOutput=$coverageDir/
+          $resolvedCoveragePath = Get-ChildItem -Path .\tests\PublishingPlatform.SDK.Tests -Recurse -Filter coverage.opencover.xml -File |
+            Where-Object { $_.FullName -like "*TestResults*Coverage*coverage.opencover.xml" } |
+            Select-Object -First 1
+          if ($null -eq $resolvedCoveragePath) {
+            Write-Error "Coverage report not found under tests/PublishingPlatform.SDK.Tests/TestResults/Coverage."
+            exit 1
+          }
           if (!(Test-Path $coveragePath)) {
             Write-Error "Coverage report not found at expected path: $coveragePath"
+            Write-Host "Discovered coverage report: $($resolvedCoveragePath.FullName)"
             exit 1
           }
           Get-Item $coveragePath | Select-Object FullName, Length, LastWriteTime | Format-List

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ var client = PublishingPlatformClientBuilder.Create(new PublishingPlatformClient
 }).Build();
 ```
 
+For quick setup in scripts or small tools, use the shorthand overload:
+
+```csharp
+var client = PublishingPlatformClientBuilder
+    .Create("https://api.books.example", "your-api-key")
+    .Build();
+```
+
 ## Initialization examples
 
 The root client exposes resource-style modules such as:
@@ -464,6 +472,31 @@ var client = PublishingPlatformClientBuilder.Create(new PublishingPlatformClient
 ```
 
 When non-idempotent retries are enabled, the SDK retries only safe transient statuses (`429`, `503`) and only when an `Idempotency-Key` is present with replayable request content.
+
+## Request-scoped options convenience overloads
+
+For publishing, distribution, and webhook registration flows, the SDK exposes extension-based convenience overloads that accept `PublishingPlatformRequestOptions`.
+
+```csharp
+using PublishingPlatform.SDK.Extensions;
+using PublishingPlatform.SDK.Options;
+
+var requestOptions = new PublishingPlatformRequestOptions
+{
+    IdempotencyKey = "publish-book-123-v1",
+};
+
+var status = await client.BookPublishing.PublishAsync(
+    "book-123",
+    new PublishBookRequest { Notes = "release-ready" },
+    requestOptions);
+```
+
+Current extension overloads map request-scoped idempotency and correlation to request headers while preserving current contracts.
+Correlation precedence is deterministic:
+- explicit request header `X-Correlation-Id` wins,
+- otherwise `PublishingPlatformRequestOptions.CorrelationId` is used when present,
+- otherwise SDK transport keeps current correlation generation behavior.
 
 ## ASP.NET Core registration (Options pattern)
 

--- a/src/PublishingPlatform.SDK/Clients/PublishingPlatformClientBuilder.cs
+++ b/src/PublishingPlatform.SDK/Clients/PublishingPlatformClientBuilder.cs
@@ -25,6 +25,34 @@ public sealed class PublishingPlatformClientBuilder
         return new PublishingPlatformClientBuilder(options);
     }
 
+    /// <summary>
+    /// Creates a builder from a minimal base URL and API key configuration.
+    /// </summary>
+    /// <param name="baseUrl">The Publishing Platform API base URL.</param>
+    /// <param name="apiKey">The API key used by the SDK transport.</param>
+    /// <returns>A configured <see cref="PublishingPlatformClientBuilder"/> instance.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="baseUrl"/> or <paramref name="apiKey"/> is empty.
+    /// </exception>
+    public static PublishingPlatformClientBuilder Create(string baseUrl, string apiKey)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            throw new ArgumentException("Base URL must not be empty.", nameof(baseUrl));
+        }
+
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            throw new ArgumentException("API key must not be empty.", nameof(apiKey));
+        }
+
+        return Create(new PublishingPlatformClientOptions
+        {
+            BaseUrl = baseUrl,
+            ApiKey = apiKey,
+        });
+    }
+
     public PublishingPlatformClientBuilder WithResiliencePipeline(IPublishingPlatformResiliencePipeline pipeline)
     {
         _customPipeline = pipeline;

--- a/src/PublishingPlatform.SDK/Extensions/PublishingPlatformRequestOptionsExtensions.cs
+++ b/src/PublishingPlatform.SDK/Extensions/PublishingPlatformRequestOptionsExtensions.cs
@@ -1,0 +1,134 @@
+using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Infrastructure.Transport;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Options;
+
+namespace PublishingPlatform.SDK.Extensions;
+
+/// <summary>
+/// Provides request-options overloads for idempotency-aware SDK operations without changing existing contracts.
+/// </summary>
+public static class PublishingPlatformRequestOptionsExtensions
+{
+    /// <summary>
+    /// Publishes a book with optional request-scoped options.
+    /// </summary>
+    /// <param name="client">The publishing client.</param>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="request">The publish payload.</param>
+    /// <param name="requestOptions">The request-scoped options.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The resulting publishing status.</returns>
+    public static Task<BookPublishingStatus> PublishAsync(
+        this IBookPublishingClient client,
+        string bookId,
+        PublishBookRequest request,
+        PublishingPlatformRequestOptions? requestOptions,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        using var scope = RequestScopedCorrelationContext.Push(requestOptions?.CorrelationId);
+        return client.PublishAsync(bookId, request, requestOptions?.IdempotencyKey, ct);
+    }
+
+    /// <summary>
+    /// Unpublishes a book with optional request-scoped options.
+    /// </summary>
+    /// <param name="client">The publishing client.</param>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="requestOptions">The request-scoped options.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The resulting publishing status.</returns>
+    public static Task<BookPublishingStatus> UnpublishAsync(
+        this IBookPublishingClient client,
+        string bookId,
+        PublishingPlatformRequestOptions? requestOptions,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        using var scope = RequestScopedCorrelationContext.Push(requestOptions?.CorrelationId);
+        return client.UnpublishAsync(bookId, requestOptions?.IdempotencyKey, ct);
+    }
+
+    /// <summary>
+    /// Schedules publishing for a book with optional request-scoped options.
+    /// </summary>
+    /// <param name="client">The publishing client.</param>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="request">The schedule payload.</param>
+    /// <param name="requestOptions">The request-scoped options.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The resulting publishing status.</returns>
+    public static Task<BookPublishingStatus> ScheduleAsync(
+        this IBookPublishingClient client,
+        string bookId,
+        ScheduleBookPublishingRequest request,
+        PublishingPlatformRequestOptions? requestOptions,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        using var scope = RequestScopedCorrelationContext.Push(requestOptions?.CorrelationId);
+        return client.ScheduleAsync(bookId, request, requestOptions?.IdempotencyKey, ct);
+    }
+
+    /// <summary>
+    /// Starts a distribution operation with optional request-scoped options.
+    /// </summary>
+    /// <param name="client">The distribution client.</param>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="request">The distribution start payload.</param>
+    /// <param name="requestOptions">The request-scoped options.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The created distribution operation snapshot.</returns>
+    public static Task<BookDistributionOperation> StartAsync(
+        this IBookDistributionClient client,
+        string bookId,
+        StartBookDistributionRequest request,
+        PublishingPlatformRequestOptions? requestOptions,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        using var scope = RequestScopedCorrelationContext.Push(requestOptions?.CorrelationId);
+        return client.StartAsync(bookId, request, requestOptions?.IdempotencyKey, ct);
+    }
+
+    /// <summary>
+    /// Retries a distribution operation with optional request-scoped options.
+    /// </summary>
+    /// <param name="client">The distribution client.</param>
+    /// <param name="bookId">The unique book identifier.</param>
+    /// <param name="operationId">The unique distribution operation identifier.</param>
+    /// <param name="requestOptions">The request-scoped options.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The distribution operation snapshot.</returns>
+    public static Task<BookDistributionOperation> RetryAsync(
+        this IBookDistributionClient client,
+        string bookId,
+        string operationId,
+        PublishingPlatformRequestOptions? requestOptions,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        using var scope = RequestScopedCorrelationContext.Push(requestOptions?.CorrelationId);
+        return client.RetryAsync(bookId, operationId, requestOptions?.IdempotencyKey, ct);
+    }
+
+    /// <summary>
+    /// Registers a webhook with optional request-scoped options.
+    /// </summary>
+    /// <param name="client">The webhooks client.</param>
+    /// <param name="request">The registration payload.</param>
+    /// <param name="requestOptions">The request-scoped options.</param>
+    /// <param name="ct">The cancellation token.</param>
+    /// <returns>The registered webhook snapshot.</returns>
+    public static Task<Webhook> RegisterAsync(
+        this IWebhooksClient client,
+        RegisterWebhookRequest request,
+        PublishingPlatformRequestOptions? requestOptions,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        using var scope = RequestScopedCorrelationContext.Push(requestOptions?.CorrelationId);
+        return client.RegisterAsync(request, requestOptions?.IdempotencyKey, ct);
+    }
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/RequestScopedCorrelationContext.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/RequestScopedCorrelationContext.cs
@@ -1,0 +1,42 @@
+using System.Threading;
+
+namespace PublishingPlatform.SDK.Infrastructure.Transport;
+
+/// <summary>
+/// Stores an optional request-scoped correlation override for the current async flow.
+/// </summary>
+internal static class RequestScopedCorrelationContext
+{
+    private static readonly AsyncLocal<string?> CorrelationId = new();
+
+    internal static string? CurrentCorrelationId => CorrelationId.Value;
+
+    internal static IDisposable Push(string? correlationId)
+    {
+        var previous = CorrelationId.Value;
+        CorrelationId.Value = correlationId;
+        return new Scope(previous);
+    }
+
+    private sealed class Scope : IDisposable
+    {
+        private readonly string? _previous;
+        private bool _disposed;
+
+        internal Scope(string? previous)
+        {
+            _previous = previous;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            CorrelationId.Value = _previous;
+            _disposed = true;
+        }
+    }
+}

--- a/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransport.cs
+++ b/src/PublishingPlatform.SDK/Infrastructure/Transport/SharedHttpTransport.cs
@@ -213,6 +213,12 @@ internal sealed class SharedHttpTransport : ISharedHttpTransport
             }
         }
 
+        var requestScopedCorrelationId = RequestScopedCorrelationContext.CurrentCorrelationId;
+        if (!string.IsNullOrWhiteSpace(requestScopedCorrelationId))
+        {
+            return requestScopedCorrelationId;
+        }
+
         return options.GenerateCorrelationIds ? _correlationIdProvider.Create() : null;
     }
 

--- a/src/PublishingPlatform.SDK/Options/PublishingPlatformRequestOptions.cs
+++ b/src/PublishingPlatform.SDK/Options/PublishingPlatformRequestOptions.cs
@@ -1,0 +1,17 @@
+namespace PublishingPlatform.SDK.Options;
+
+/// <summary>
+/// Defines request-scoped SDK options for additive overloads and extension-based convenience APIs.
+/// </summary>
+public sealed class PublishingPlatformRequestOptions
+{
+    /// <summary>
+    /// Gets or sets an optional idempotency key for retry-safe mutating operations.
+    /// </summary>
+    public string? IdempotencyKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional correlation identifier for future request-scoped propagation.
+    /// </summary>
+    public string? CorrelationId { get; set; }
+}

--- a/src/PublishingPlatform.SDK/PublishingPlatform.SDK.csproj
+++ b/src/PublishingPlatform.SDK/PublishingPlatform.SDK.csproj
@@ -4,7 +4,19 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
+    <Description>Reference SDK for Publishing Platform integrations focused on secure, book-lifecycle workflows.</Description>
+    <PackageTags>publishing;books;sdk;api-client</PackageTags>
+    <PackageProjectUrl>https://github.com/pavsavov/reading-platform-sdk-csharp</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <NoWarn>$(NoWarn);1591;1587</NoWarn>
+    <DebugType>none</DebugType>
+    <DebugSymbols>false</DebugSymbols>
+    <PublishRepositoryUrl>false</PublishRepositoryUrl>
+    <EmbedUntrackedSources>false</EmbedUntrackedSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PublishingPlatform.SDK/PublishingPlatform.SDK.csproj
+++ b/src/PublishingPlatform.SDK/PublishingPlatform.SDK.csproj
@@ -23,6 +23,11 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(CollectCoverage)' == 'true'">
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Http" />

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/PublishingPlatformClientBuilderConvenienceOverloadTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/PublishingPlatformClientBuilderConvenienceOverloadTests.cs
@@ -1,0 +1,52 @@
+using Bogus;
+using PublishingPlatform.SDK.Clients;
+using PublishingPlatform.SDK.Exceptions;
+
+namespace PublishingPlatform.SDK.Tests.Infrastructure;
+
+public sealed class PublishingPlatformClientBuilderConvenienceOverloadTests
+{
+    [Fact]
+    public void Create_WithValidBaseUrlAndApiKey_BuildsClient()
+    {
+        Randomizer.Seed = new Random(110);
+        var faker = new Faker();
+        var host = faker.Internet.DomainName();
+        var apiKey = faker.Random.AlphaNumeric(32);
+
+        var client = PublishingPlatformClientBuilder
+            .Create($"https://{host}", apiKey)
+            .Build();
+
+        client.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Create_WithWhitespaceBaseUrl_ThrowsArgumentException()
+    {
+        var act = () => PublishingPlatformClientBuilder.Create(" ", "valid-key");
+
+        var exception = act.Should().Throw<ArgumentException>().Which;
+        exception.ParamName.Should().Be("baseUrl");
+    }
+
+    [Fact]
+    public void Create_WithWhitespaceApiKey_ThrowsArgumentException()
+    {
+        var act = () => PublishingPlatformClientBuilder.Create("https://api.books.example", " ");
+
+        var exception = act.Should().Throw<ArgumentException>().Which;
+        exception.ParamName.Should().Be("apiKey");
+    }
+
+    [Fact]
+    public void Create_WithHttpBaseUrl_ThrowsPublishingPlatformConfigurationExceptionOnBuild()
+    {
+        var act = () => PublishingPlatformClientBuilder
+            .Create("http://api.books.example", "valid-key")
+            .Build();
+
+        var exception = act.Should().Throw<PublishingPlatformConfigurationException>().Which;
+        exception.Message.Should().Be("BaseUrl must use HTTPS.");
+    }
+}

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/PublishingPlatformRequestOptionsExtensionsTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/PublishingPlatformRequestOptionsExtensionsTests.cs
@@ -91,6 +91,30 @@ public sealed class PublishingPlatformRequestOptionsExtensionsTests
     }
 
     [Fact]
+    public async Task ScheduleAsync_ForwardsIdempotencyKey_FromRequestOptions()
+    {
+        var idempotencyKey = new Faker().Random.Guid().ToString("N");
+        var client = Substitute.For<IBookPublishingClient>();
+        client.ScheduleAsync(
+                "book-1",
+                Arg.Any<ScheduleBookPublishingRequest>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new BookPublishingStatus { BookId = "book-1", Status = "scheduled" }));
+
+        await client.ScheduleAsync(
+            "book-1",
+            new ScheduleBookPublishingRequest { ScheduledAt = DateTimeOffset.UtcNow.AddHours(1) },
+            new PublishingPlatformRequestOptions { IdempotencyKey = idempotencyKey });
+
+        await client.Received(1).ScheduleAsync(
+            "book-1",
+            Arg.Any<ScheduleBookPublishingRequest>(),
+            idempotencyKey,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task UnpublishAsync_WithNullRequestOptions_ForwardsNullIdempotencyKey()
     {
         var client = Substitute.For<IBookPublishingClient>();

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/PublishingPlatformRequestOptionsExtensionsTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/PublishingPlatformRequestOptionsExtensionsTests.cs
@@ -1,0 +1,194 @@
+using Bogus;
+using PublishingPlatform.SDK.Abstractions;
+using PublishingPlatform.SDK.Extensions;
+using PublishingPlatform.SDK.Models;
+using PublishingPlatform.SDK.Options;
+
+namespace PublishingPlatform.SDK.Tests.Infrastructure;
+
+public sealed class PublishingPlatformRequestOptionsExtensionsTests
+{
+    [Fact]
+    public async Task PublishAsync_ForwardsIdempotencyKey_FromRequestOptions()
+    {
+        Randomizer.Seed = new Random(111);
+        var faker = new Faker();
+        var bookId = $"book-{faker.Random.Int(10, 99)}";
+        var idempotencyKey = faker.Random.Guid().ToString("N");
+
+        var client = Substitute.For<IBookPublishingClient>();
+        var expected = new BookPublishingStatus { BookId = bookId, Status = "published" };
+        client.PublishAsync(
+                bookId,
+                Arg.Any<PublishBookRequest>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expected));
+
+        var result = await client.PublishAsync(
+            bookId,
+            new PublishBookRequest { Notes = "ready" },
+            new PublishingPlatformRequestOptions { IdempotencyKey = idempotencyKey });
+
+        result.Should().BeSameAs(expected);
+        await client.Received(1).PublishAsync(
+            bookId,
+            Arg.Is<PublishBookRequest>(request => request.Notes == "ready"),
+            idempotencyKey,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StartAsync_ForwardsIdempotencyKey_FromRequestOptions()
+    {
+        var idempotencyKey = new Faker().Random.Guid().ToString("N");
+        var client = Substitute.For<IBookDistributionClient>();
+        client.StartAsync(
+                "book-1",
+                Arg.Any<StartBookDistributionRequest>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new BookDistributionOperation { BookId = "book-1", OperationId = "op-1", Status = "pending" }));
+
+        await client.StartAsync(
+            "book-1",
+            new StartBookDistributionRequest { Channels = ["mobile"] },
+            new PublishingPlatformRequestOptions { IdempotencyKey = idempotencyKey });
+
+        await client.Received(1).StartAsync(
+            "book-1",
+            Arg.Is<StartBookDistributionRequest>(request =>
+                request.Channels.Count == 1
+                && request.Channels[0] == "mobile"),
+            idempotencyKey,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RegisterAsync_ForwardsIdempotencyKey_FromRequestOptions()
+    {
+        var idempotencyKey = new Faker().Random.Guid().ToString("N");
+        var client = Substitute.For<IWebhooksClient>();
+        client.RegisterAsync(
+                Arg.Any<RegisterWebhookRequest>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new Webhook { Id = "whk-1", EndpointUrl = "https://hooks.example.com", Events = ["book.published"] }));
+
+        await client.RegisterAsync(
+            new RegisterWebhookRequest
+            {
+                EndpointUrl = "https://hooks.example.com",
+                Events = ["book.published"],
+                IsActive = true,
+            },
+            new PublishingPlatformRequestOptions { IdempotencyKey = idempotencyKey });
+
+        await client.Received(1).RegisterAsync(
+            Arg.Is<RegisterWebhookRequest>(request => request.EndpointUrl == "https://hooks.example.com"),
+            idempotencyKey,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UnpublishAsync_WithNullRequestOptions_ForwardsNullIdempotencyKey()
+    {
+        var client = Substitute.For<IBookPublishingClient>();
+        client.UnpublishAsync(
+                "book-1",
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new BookPublishingStatus { BookId = "book-1", Status = "unpublished" }));
+
+        await client.UnpublishAsync("book-1", requestOptions: null, ct: CancellationToken.None);
+
+        await client.Received(1).UnpublishAsync(
+            "book-1",
+            Arg.Is<string?>(value => value == null),
+            CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task RetryAsync_WithRequestOptionsWithoutIdempotencyKey_ForwardsNullIdempotencyKey()
+    {
+        var client = Substitute.For<IBookDistributionClient>();
+        client.RetryAsync(
+                "book-1",
+                "op-1",
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new BookDistributionOperation { BookId = "book-1", OperationId = "op-1", Status = "pending" }));
+
+        await client.RetryAsync(
+            "book-1",
+            "op-1",
+            new PublishingPlatformRequestOptions { CorrelationId = "corr-1" },
+            CancellationToken.None);
+
+        await client.Received(1).RetryAsync(
+            "book-1",
+            "op-1",
+            Arg.Is<string?>(value => value == null),
+            CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task PublishAsync_ForwardsNullIdempotency_WhenOnlyCorrelationIdProvided()
+    {
+        var client = Substitute.For<IBookPublishingClient>();
+        client.PublishAsync(
+                "book-1",
+                Arg.Any<PublishBookRequest>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new BookPublishingStatus { BookId = "book-1", Status = "published" }));
+
+        await client.PublishAsync(
+            "book-1",
+            new PublishBookRequest { Notes = "ready" },
+            new PublishingPlatformRequestOptions { CorrelationId = "corr-explicit" });
+
+        await client.Received(1).PublishAsync(
+            "book-1",
+            Arg.Any<PublishBookRequest>(),
+            Arg.Is<string?>(value => value == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PublishAsync_ForwardsNullIdempotency_WhenCorrelationIdIsWhitespace()
+    {
+        var client = Substitute.For<IBookPublishingClient>();
+        client.PublishAsync(
+                "book-1",
+                Arg.Any<PublishBookRequest>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new BookPublishingStatus { BookId = "book-1", Status = "published" }));
+
+        await client.PublishAsync(
+            "book-1",
+            new PublishBookRequest { Notes = "ready" },
+            new PublishingPlatformRequestOptions { CorrelationId = "  " });
+
+        await client.Received(1).PublishAsync(
+            "book-1",
+            Arg.Any<PublishBookRequest>(),
+            Arg.Is<string?>(value => value == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PublishAsync_WithNullClient_ThrowsArgumentNullException()
+    {
+        IBookPublishingClient? client = null;
+
+        var act = async () => await client!.PublishAsync(
+            "book-1",
+            new PublishBookRequest(),
+            new PublishingPlatformRequestOptions { IdempotencyKey = "id-1" });
+
+        var exception = await act.Should().ThrowAsync<ArgumentNullException>();
+        exception.Which.ParamName.Should().Be("client");
+    }
+}

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/RequestScopedCorrelationContextTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/RequestScopedCorrelationContextTests.cs
@@ -1,0 +1,39 @@
+using PublishingPlatform.SDK.Infrastructure.Transport;
+
+namespace PublishingPlatform.SDK.Tests.Infrastructure;
+
+public sealed class RequestScopedCorrelationContextTests
+{
+    [Fact]
+    public void Push_SetsCurrentCorrelationId_AndRestoresOnDispose()
+    {
+        RequestScopedCorrelationContext.CurrentCorrelationId.Should().BeNull();
+
+        using (RequestScopedCorrelationContext.Push("corr-outer"))
+        {
+            RequestScopedCorrelationContext.CurrentCorrelationId.Should().Be("corr-outer");
+
+            using (RequestScopedCorrelationContext.Push("corr-inner"))
+            {
+                RequestScopedCorrelationContext.CurrentCorrelationId.Should().Be("corr-inner");
+            }
+
+            RequestScopedCorrelationContext.CurrentCorrelationId.Should().Be("corr-outer");
+        }
+
+        RequestScopedCorrelationContext.CurrentCorrelationId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Dispose_CanBeCalledTwice_WithoutMutatingStateAgain()
+    {
+        var scope = RequestScopedCorrelationContext.Push("corr-1");
+        RequestScopedCorrelationContext.CurrentCorrelationId.Should().Be("corr-1");
+
+        scope.Dispose();
+        RequestScopedCorrelationContext.CurrentCorrelationId.Should().BeNull();
+
+        scope.Dispose();
+        RequestScopedCorrelationContext.CurrentCorrelationId.Should().BeNull();
+    }
+}

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/ResilienceAndTransportTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/ResilienceAndTransportTests.cs
@@ -82,6 +82,58 @@ public sealed class ResilienceAndTransportTests
     }
 
     [Fact]
+    public async Task SendAsync_UsesRequestScopedCorrelationOverride_WhenHeaderMissing()
+    {
+        var correlationProvider = new FixedCorrelationIdProvider("generated-correlation");
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.test") };
+        var transport = CreateDiagnosticsTransport(
+            httpClient,
+            correlationProvider,
+            new PublishingPlatformClientOptions
+            {
+                Diagnostics = new DiagnosticsOptions(),
+            });
+
+        using (RequestScopedCorrelationContext.Push("request-scope-correlation"))
+        {
+            await transport.SendAsync(HttpMethod.Get, "/books", null, null, "Books.GetById", CancellationToken.None, "Books");
+        }
+
+        handler.LastRequest!.Headers.TryGetValues(SharedHttpTransport.CorrelationHeaderName, out var values).Should().BeTrue();
+        values.Should().ContainSingle().Which.Should().Be("request-scope-correlation");
+        correlationProvider.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SendAsync_PrefersExplicitHeader_OverRequestScopedCorrelationOverride()
+    {
+        var correlationProvider = new FixedCorrelationIdProvider("generated-correlation");
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.test") };
+        var transport = CreateDiagnosticsTransport(
+            httpClient,
+            correlationProvider,
+            new PublishingPlatformClientOptions
+            {
+                Diagnostics = new DiagnosticsOptions(),
+            });
+        var headers = new Dictionary<string, string>
+        {
+            [SharedHttpTransport.CorrelationHeaderName] = "caller-correlation",
+        };
+
+        using (RequestScopedCorrelationContext.Push("request-scope-correlation"))
+        {
+            await transport.SendAsync(HttpMethod.Get, "/books", null, headers, "Books.GetById", CancellationToken.None, "Books");
+        }
+
+        handler.LastRequest!.Headers.TryGetValues(SharedHttpTransport.CorrelationHeaderName, out var values).Should().BeTrue();
+        values.Should().ContainSingle().Which.Should().Be("caller-correlation");
+        correlationProvider.CallCount.Should().Be(0);
+    }
+
+    [Fact]
     public async Task SendAsync_UsesCustomCorrelationHeaderName()
     {
         const string headerName = "X-Trace-Id";

--- a/tests/PublishingPlatform.SDK.Tests/Infrastructure/ResilienceAndTransportTests.cs
+++ b/tests/PublishingPlatform.SDK.Tests/Infrastructure/ResilienceAndTransportTests.cs
@@ -134,6 +134,30 @@ public sealed class ResilienceAndTransportTests
     }
 
     [Fact]
+    public async Task SendAsync_UsesGeneratedCorrelationId_WhenRequestScopedCorrelationIsWhitespace()
+    {
+        var correlationProvider = new FixedCorrelationIdProvider("generated-correlation");
+        using var handler = new RecordingHandler((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.example.test") };
+        var transport = CreateDiagnosticsTransport(
+            httpClient,
+            correlationProvider,
+            new PublishingPlatformClientOptions
+            {
+                Diagnostics = new DiagnosticsOptions(),
+            });
+
+        using (RequestScopedCorrelationContext.Push("   "))
+        {
+            await transport.SendAsync(HttpMethod.Get, "/books", null, null, "Books.GetById", CancellationToken.None, "Books");
+        }
+
+        handler.LastRequest!.Headers.TryGetValues(SharedHttpTransport.CorrelationHeaderName, out var values).Should().BeTrue();
+        values.Should().ContainSingle().Which.Should().Be("generated-correlation");
+        correlationProvider.CallCount.Should().Be(1);
+    }
+
+    [Fact]
     public async Task SendAsync_UsesCustomCorrelationHeaderName()
     {
         const string headerName = "X-Trace-Id";


### PR DESCRIPTION
# Summary

This PR enables request-scoped correlation propagation for `PublishingPlatformRequestOptions` without changing existing public client method signatures and applying selected Stripe-style SDK improvements while preserving existing security and architecture rules.

What changed:
- Added internal request-scoped correlation context using `AsyncLocal` for extension-overload flows.
- Updated request-option extension overloads to push `CorrelationId` scope per request while preserving idempotency forwarding.
- Updated shared transport correlation resolution precedence:
  1. explicit correlation header
  2. request-scoped correlation override
  3. generated correlation id
- Updated README docs to describe current correlation behavior and precedence.
- Added/updated tests for extension behavior and transport precedence edge cases.
What changed:
- Added `PublishingPlatformRequestOptions` as an additive request-scoped options model.
- Added extension-based convenience overloads for idempotency-aware operations on publishing, distribution, and webhook registration clients.
- Added shorthand `PublishingPlatformClientBuilder.Create(baseUrl, apiKey)` for quick non-DI setup.
- Improved package quality/hardening settings in SDK project configuration.
- Expanded CI quality workflow with mock API build validation and package generation (`dotnet pack`).
- Updated README with shorthand builder usage and request-scoped options examples.

API impact:
- Additive only.
- No existing public method signatures were changed.
- New extension overloads and builder factory overload are available to consumers.
API impact:
- No breaking public API/interface contract changes.
- Existing extension overload signatures remain the same.

# Validation

- [x] `dotnet test tests/PublishingPlatform.SDK.Tests/PublishingPlatform.SDK.Tests.csproj -v minimal`
- [x] Added/updated tests for:
  - explicit request-scoped correlation propagation
  - explicit header precedence over request-scoped/generated values
  - null/empty/whitespace correlation fallback behavior

# Release Please Override (Required for releasable changes)

```text
BEGIN_COMMIT_OVERRIDE
feat: propagate request-scoped correlation id through request options extensions
END_COMMIT_OVERRID

